### PR TITLE
Adds DuplicateDashboard class and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Or install it yourself as:
 
     $ gem install superset
 
-Open a pry console with the gem directly using `bin/console`
 
 ## Usage
+
+Within the gems root dir, open a pry console with the gem directly using `bin/console`
 
 Assumption is that this Gem would be used for general api calls and/or for guest token retrieval when setting up applications to use the superset embedded dashboard workflow.
 
@@ -37,61 +38,69 @@ Env Var Credentials setup as follows
 - for embedded user calls setup creds in `ENV['SUPERSET_EMBEDDED_USERNAME']` and `ENV['SUPERSET_EMBEDDED_PASSWORD']`
 - configure your superset host in `ENV['SUPERSET_HOST']`
 
-Copy the `env.sample` to `.env` and add edit values where applicable.  In your ruby console load the env vars with `load '.env'`
+Copy the `env.sample` to `.env` and add edit values where applicable.  
+Opening a console with `bin/console` will then auto load the `.env` file.
 
 ## API calls
 
-Generally they follow the convention/path of the Superset API strucuture.  
+Generally they follow the convention/path of the Superset API strucuture as per the swagger docs.
+
+ref https://superset.apache.org/docs/api/
+
+Limited support for filters is enabled.  Pagination is supported.
+
+Primary methods across majority of api calls are
+- response : list the full API response
+- result : list just the result attr array
+- list : displays a formatted output to console, handy for quick investigation of objects
+- call : is a alias to list on Get and List requests
 
 ```
 # some examples
-Superset::Dashboard::Get.new(1).result
-Superset::Dashboard::Export.new(1).perform
-Superset::Dashboard::Import.new(zip_file: 'my_dashboard.zip').perform
+Superset::Dashboard::Get.call(1)
++----------------------------+
+|     World Bank's Data      |
++----------------------------+
+| Charts                     |
++----------------------------+
+| % Rural                    |
+| Region Filter              |
+| Life Expectancy VS Rural % |
+| Box plot                   |
+| Most Populated Countries   |
+| World's Population         |
+| World's Pop Growth         |
+| Rural Breakdown            |
+| Treemap                    |
+| Growth Rate                |
++----------------------------+
+
+Superset::Dashboard::List.new(title_contains: 'test').list
+D, [2024-03-05T10:48:10.053139 #5095] DEBUG -- : Happi: GET https://your-ss-host/api/v1/dashboard/?q=(filters:!((col:dashboard_title,opr:ct,value:'test')),page:0,page_size:100), {}
++----+-------------------------------------+-----------+-------------------------------------------------------+
+|                                     Superset::Dashboard::List                                                |
++----+-------------------------------------+-----------+-------------------------------------------------------+
+| Id | Dashboard title                     | Status    | Url                                                   |
++----+-------------------------------------+-----------+-------------------------------------------------------+
+| 22 | Embedded Test 1                     | published | https://your-ss-host/superset/dashboard/22/           |
+| 36 | Test Embedded 2                     | published | https://your-ss-host/superset/dashboard/36/           |
+| 7  | Unicode Test                        | published | https://your-ss-host/superset/dashboard/unicode-test/ |
++----+-------------------------------------+-----------+-------------------------------------------------------+
+
+
+# Default page num is 100
+Superset::Dashboard::List.new().list
+
+# second set of 100 dashboards
+Superset::Dashboard::List.new(page_num: 1).list
+
 ```
 
-All List endpoints have a `.call` method to pull the first 100 records or the ability to search.
-
-```
-Superset::Dashboard::List.call
-DEBUG -- : Happi: GET https://your-superset-host.com/api/v1/dashboard/?q=(page:0,page_size:100), {}
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-|                                             Superset::Dashboard::List                                                |
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-| Id | Dashboard title                   | Status    | Url                                                             |
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-| 15 | Innovation Day: Staging Test001   | published | https://your-superset-host.com/superset/dashboard/25/           |
-| 66 | Acme EXPORT TEST                  | published | https://your-superset-host.com/superset/dashboard/36/   |
-| 69 | Overview: Acme Stage              | draft     | https://your-superset-host.com/superset/dashboard/59/   |
-...................
-+----+-----------------------------------+-----------+-----------------------------------------------------------------------------+
-```
-
-### Optionally can add a search term to most list endpoints
-
-```
-Superset::Dashboard::List.new(title_contains: 'innov').list
-DEBUG -- : Happi: GET https://your-superset-host.com/api/v1/dashboard/?q=(filters:!((col:dashboard_title,opr:ct,value:innov)),page:0,page_size:100), {}
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-|                                             Superset::Dashboard::List                                                |
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-| Id | Dashboard title                   | Status    | Url                                                             |
-+----+-----------------------------------+-----------+-----------------------------------------------------------------+
-| 15 | Innovation Day: Staging Test001   | published | https://your-superset-host.com/superset/dashboard/25/           |
-+----+-------------------------------------------------+-----------+-------------------------------------------------------------------+
-
-Superset::Dashboard::Embedded::Get.new(15).result
-D, [2024-01-23T09:23:32.345514 #14893] DEBUG -- : Happi: GET https://your-superset-host.com/api/v1/dashboard/15/embedded, {}
-=> [{"allowed_domains"=>["https://acme.com/", "https://acme-staging.com/"],
-  "changed_by"=>{"first_name"=>"Jonathon", "id"=>9, "last_name"=>"Batson", "username"=>"some-superset-user-uuid"},
-  "changed_on"=>"2023-12-19T05:38:06.923548",
-  "dashboard_id"=>"15",
-  "uuid"=>"some-superset-dashboard-uuid"}]
-```
 
 ### Fetch a Guest Token
 
-Assuming you have setup your Dashboard in Superset to be embedded and that your creds are setup in  `ENV['SUPERSET_EMBEDDED_USERNAME']` and `ENV['SUPERSET_EMBEDDED_PASSWORD']`
+Assuming you have setup your Dashboard in Superset to be embedded and that your creds are setup in  
+`ENV['SUPERSET_EMBEDDED_USERNAME']` and `ENV['SUPERSET_EMBEDDED_PASSWORD']`
 
 ```
 Superset::GuestToken.new(embedded_dashboard_id: '15').guest_token

--- a/lib/superset/chart/get.rb
+++ b/lib/superset/chart/get.rb
@@ -12,8 +12,33 @@ module Superset
         self.new(id).list
       end
 
+      def perform
+        response
+        self
+      end
+
       def result
         [ super ]
+      end
+
+      def datasource_id
+        if result.first['query_context'].present? && JSON.parse(result.first['query_context'])['datasource'].present?
+          JSON.parse(result.first['query_context'])['datasource']['id']
+        elsif result.first['params'].present? && JSON.parse(result.first['params'])['datasource'].present?
+          JSON.parse(result.first['params'])['datasource'].match(/^\d+/)[0].to_i
+        end
+      end
+
+      def owner_ids
+        result.first['owners'].map{|o| o['id']}
+      end
+
+      def params
+        JSON.parse(result.first['params']) if result.first['params'].present?
+      end
+
+      def query_context
+        JSON.parse(result.first['query_context']) if result.first['query_context'].present?
       end
 
       private
@@ -23,7 +48,7 @@ module Superset
       end
 
       def list_attributes
-        %w(id slice_name owners dashboards)
+        %w(id slice_name owners)
       end
 
     end

--- a/lib/superset/chart/list.rb
+++ b/lib/superset/chart/list.rb
@@ -2,10 +2,11 @@ module Superset
   module Chart
     class List < Superset::Request
 
-      attr_reader :name_contains
+      attr_reader :name_contains, :dashboard_id_eq
 
-      def initialize(page_num: 0, name_contains: '')
+      def initialize(page_num: 0, name_contains: '', dashboard_id_eq: '')
         @name_contains = name_contains
+        @dashboard_id_eq = dashboard_id_eq
         super(page_num: page_num)
       end
 
@@ -34,7 +35,14 @@ module Superset
       end
 
       def filters
-        "filters:!((col:slice_name,opr:ct,value:'#{name_contains}'))," if name_contains.present?
+        # TODO filtering across all classes needs a refactor to support multiple options in a more flexible way
+        filter_set = []
+        filter_set << "(col:slice_name,opr:ct,value:'#{name_contains}')" if name_contains.present?
+        filter_set << "(col:datasource_id,opr:eq,value:#{dashboard_id_eq})" if dashboard_id_eq.present?
+
+        unless filter_set.empty?
+          "filters:!(" + filter_set.join(',') + "),"
+        end
       end
 
       def list_attributes
@@ -44,8 +52,6 @@ module Superset
       def list_dashboard_attributes
         ['id', 'slice_name', 'dashboards']
       end
-
-  
     end
   end
 end

--- a/lib/superset/dashboard/charts/list.rb
+++ b/lib/superset/dashboard/charts/list.rb
@@ -12,6 +12,10 @@ module Superset
           @id = id
         end
 
+        def chart_ids
+          result.map { |c| c[:id] }
+        end
+
         private
 
         def route

--- a/lib/superset/dashboard/copy.rb
+++ b/lib/superset/dashboard/copy.rb
@@ -6,18 +6,19 @@ module Superset
   module Dashboard
     class Copy < Superset::Request
 
-      attr_reader :id, :duplicate_slices
+      attr_reader :source_dashboard_id, :duplicate_slices
 
-      def initialize(id: , duplicate_slices: false)
-        @id = id
+      def initialize(source_dashboard_id: , duplicate_slices: false)
+        @source_dashboard_id = source_dashboard_id
         @duplicate_slices = duplicate_slices # boolean indicates whether to duplicate charts OR keep the new dashboard pointing to the same charts as the original
       end
 
       def perform
-        raise "Error: id integer is required" unless id.present? && id.is_a?(Integer)
+        raise "Error: source_dashboard_id integer is required" unless source_dashboard_id.present? && source_dashboard_id.is_a?(Integer)
         raise "Error: duplicate_slices must be a boolean" unless duplicate_slices_is_boolean?
 
-        new_dashboard_id
+        response
+        self
       end
 
       def params
@@ -33,14 +34,14 @@ module Superset
         @response ||= client.post(route, params)
       end
 
-      def new_dashboard_id
+      def id
         response["result"]["id"]
       end
 
       private
 
       def route
-        "dashboard/#{id}/copy/"
+        "dashboard/#{source_dashboard_id}/copy/"
       end
 
       def source_dashboard_json_metadata_with_positions
@@ -53,7 +54,7 @@ module Superset
 
       def source_dashboard
         @source_dashboard ||= begin
-          dash = Get.new(id)
+          dash = Get.new(source_dashboard_id)
           dash.response
           dash
         rescue => e

--- a/lib/superset/services/duplicate_dashboard.rb
+++ b/lib/superset/services/duplicate_dashboard.rb
@@ -1,0 +1,116 @@
+# Assumptions
+# - The source dashboard is in the same Superset instance as the target database and target schema
+# - All charts datasets on the source dashboard are pointing to the same database schema
+
+
+module Superset
+  module Services
+    class DuplicateDashboard < Superset::Request
+
+      attr_reader :source_dashboard_id, :target_schema, :target_database_id
+
+      def initialize(source_dashboard_id:, target_schema:, target_database_id: )
+        @source_dashboard_id = source_dashboard_id
+        @target_schema = target_schema
+        @target_database_id = target_database_id
+      end
+
+      def perform
+        validate_params
+
+        # create a new_dashboard by copying the source_dashboard using with 'duplicate_slices: true' to get a new set of charts.
+        new_dashboard
+
+        # Pull the Datasets for all charts on the source dashboard  
+        # currently the new_dashboard charts(slices) all point to these same datasets from the orig source dashboard 
+        source_dashboard_datasets
+
+        # Duplicate these Datasets to the new target schema and target database
+        duplicate_source_dashboard_datasets
+
+        # Update the Charts on the New Dashboard with the New Datasets
+        update_charts_with_new_datasets
+
+      end
+
+      # private
+
+      def dataset_duplication_tracker
+        @dataset_duplication_tracker ||= []
+      end
+
+      def update_charts_with_new_datasets
+
+        # get all chart ids for the new dashboard
+        chart_ids_list = Superset::Dashboard::Charts::List.new(new_dashboard.id).chart_ids
+
+        # for each chart, update the charts current dataset_id with the new dataset_id
+        chart_ids_list.each do |chart_id|
+
+          # get the CURRENT dataset_id for the chart
+          current_chart_dataset_id = Superset::Chart::Get.new(chart_id).datasource_id
+
+          # find the new dataset_id for the chart, based on the current_chart_dataset_id
+          new_dataset_id = dataset_duplication_tracker.find { |dataset| dataset[:source_dataset_id] == current_chart_dataset_id }&.fetch(:new_dataset_id, nil)
+
+          # update the chart to target the new dataset_id
+          chart_update = Superset::Chart::UpdateDataset.new(chart_id: chart_id, target_dataset_id: new_dataset_id)
+          chart_update.response
+        end
+      end
+
+      
+
+      def duplicate_source_dashboard_datasets
+        source_dashboard_datasets.each do |dataset|
+          # duplicate the dataset
+          new_dataset = Superset::Dataset::Duplicate.new(source_dataset_id: dataset[:id], new_dataset_name: "#{dataset[:datasource_name]} #{target_schema} DUPLICATION")
+          new_dataset_id = new_dataset.perform
+          dataset_duplication_tracker <<  { source_dataset_id: dataset[:id], new_dataset_id: new_dataset_id }
+
+          # update the new dataset with the target schema and target database
+          update_dataset = Superset::Dataset::UpdateSchema.new(source_dataset_id: new_dataset_id, target_database_id: target_database_id, target_schema: target_schema)
+          update_dataset.response
+        end
+      end
+
+      def new_dashboard
+        @new_dashboard ||= Superset::Dashboard::Copy.new(
+            source_dashboard_id: source_dashboard_id,
+            duplicate_slices:    true
+          ).perform
+      end
+
+      # retrieve the datasets for the that we will duplicate
+      def source_dashboard_datasets
+        @source_dashboard_datasets ||= Superset::Dashboard::Datasets::List.new(source_dashboard_id).datasets_details
+      end
+
+      def validate_params
+        # params validations
+        raise "Error: source_dashboard_id integer is required" unless source_dashboard_id.present? && source_dashboard_id.is_a?(Integer)
+        raise "Error: target_schema string is required" unless target_schema.present? && target_schema.is_a?(String)
+        raise "Error: target_database_id integer is required" unless target_database_id.present? && target_database_id.is_a?(Integer)
+
+        # dashboard validations
+        # Validation of source dashboard existance will occur inside the new_dashboard call
+
+        # schema validations
+        raise "Error: Schema #{target_schema} does not exist in target database: #{target_database_id}" unless target_database_available_schemas.include?(target_schema)
+        raise "Error: The souce_dashboard_id #{source_dashboard_id} datasets point to more than one schema. Schema list is #{source_dashboard_schemas.join(',')}" if source_dashboard_has_more_than_one_schema?
+      end
+
+      def target_database_available_schemas
+        Superset::Database::GetSchemas.call(target_database_id)
+      end
+
+      def source_dashboard_has_more_than_one_schema?
+        source_dashboard_schemas.count > 1
+      end
+
+      def source_dashboard_schemas
+        source_dashboard_datasets.map { |dataset| dataset[:schema] }.uniq
+      end
+    end
+  end
+end

--- a/spec/superset/chart/get_spec.rb
+++ b/spec/superset/chart/get_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 RSpec.describe Superset::Chart::Get do
   subject { described_class.new(id) }
   let(:id) { 54507 }
+  let(:datasource_id) { 299 }
+  let(:params) { "{\"datasource\":\"#{datasource_id}__table\"}" }
+  let(:query_context) { "{\"datasource\":{\"id\":#{datasource_id},\"type\":\"table\"}}" }
   let(:result) do
     [{
       "cache_timeout"=>nil,
@@ -13,9 +16,9 @@ RSpec.describe Superset::Chart::Get do
       "description"=>nil,
       "id"=>54507,
       "is_managed_externally"=>false,
-      "owners"=>[{"first_name"=>"Jonathon", "id"=>9, "last_name"=>"Batson"}],
-      "params"=>"{}",
-      "query_context"=>nil,
+      "owners"=>[{"first_name"=>"Jay", "id"=>9, "last_name"=>"Bee"}, {"first_name"=>"Ron", "id"=>8, "last_name"=>"Vee"}],
+      "params"=>params,
+      "query_context"=>query_context,
       "slice_name"=>"JRStg DoB per Year",
       "tags"=>[{"id"=>1, "name"=>"owner:9", "type"=>3}, {"id"=>28, "name"=>"type:chart", "type"=>2}],
       "thumbnail_url"=>"/api/v1/chart/54507/thumbnail/1595a10937091faff0aed5df628a1292/",
@@ -37,7 +40,55 @@ RSpec.describe Superset::Chart::Get do
 
   describe '#rows' do
     specify do
-      expect(subject.rows).to eq [["54507", "JRStg DoB per Year", "[{\"first_name\"=>\"Jonathon\", \"id\"=>9, \"last_name\"=>\"Batson\"}]", "[]"]]
+      expect(subject.rows).to eq [[
+        "54507", 
+        "JRStg DoB per Year", 
+        "[{\"first_name\"=>\"Jay\", \"id\"=>9, \"last_name\"=>\"Bee\"}, {\"first_name\"=>\"Ron\", \"id\"=>8, \"last_name\"=>\"Vee\"}]"
+      ]]
+    end
+  end
+
+  describe '#datasource_id' do
+    context 'with query_context containing the datasource_id' do
+      specify do
+        expect(subject.datasource_id).to eq(datasource_id)
+      end
+    end
+ 
+    context 'with query_context not containing the datasource_id' do
+      let(:query_context) { "{}" }
+      let(:datasource_id) { 300 }
+
+      specify 'reverts to params datasource' do
+        expect(subject.datasource_id).to eq(datasource_id)
+      end
+    end
+
+    context 'with params and query context empty' do
+      let(:params) { "{}" }
+      let(:query_context) { "{}" }
+
+      specify 'reverts to params datasource' do
+        expect(subject.datasource_id).to eq(nil)
+      end
+    end
+  end
+
+  describe '#owner_ids' do
+    specify do
+      expect(subject.owner_ids).to match_array([9,8])
+    end
+  end
+
+  describe '#params' do
+    specify do
+      expect(subject.params).to eq(JSON.parse(params))
+    end
+  end
+
+  describe '#query_context' do
+    specify do
+      expect(subject.query_context).to eq(JSON.parse(query_context))
     end
   end
 end

--- a/spec/superset/chart/list_spec.rb
+++ b/spec/superset/chart/list_spec.rb
@@ -117,5 +117,16 @@ RSpec.describe Superset::Chart::List do
       end
     end
 
+    context 'with multiple filter set' do
+      subject { described_class.new(name_contains: 'birth', dashboard_id_eq: 3) }
+
+      specify do
+        expect(subject.query_params).to eq(
+          "filters:!(" \
+          "(col:slice_name,opr:ct,value:'birth')," \
+          "(col:datasource_id,opr:eq,value:3)" \
+          "),page:0,page_size:100")
+      end
+    end
   end
 end

--- a/spec/superset/chart/update_dataset_spec.rb
+++ b/spec/superset/chart/update_dataset_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Superset::Chart::UpdateDataset do
 
   let(:chart_id) { 226 }
   let(:target_dataset_id) { 242 }
-  let(:chart) do
+  let(:chart) { instance_double(Superset::Chart::Get) }
+  let(:chart_response) do
     {
       "cache_timeout"=>nil,
       "certification_details"=>nil,
@@ -15,9 +16,9 @@ RSpec.describe Superset::Chart::UpdateDataset do
       "changed_on_delta_humanized"=>"14 days ago",
       "dashboards"=>[],
       "description"=>nil,
-      "id"=>226,
+      "id"=>chart_id,
       "is_managed_externally"=>false,
-      "owners"=>[{"first_name"=>"Jonathon", "id"=>9, "last_name"=>"Batson"}],
+      "owners"=>[{"first_name"=>"Jay", "id"=>9, "last_name"=>"Bee"}],
       "query_context"=>nil,
       "slice_name"=>"JRStg DoB per Year",
       "tags"=>[{"id"=>1, "name"=>"owner:9", "type"=>3}, {"id"=>28, "name"=>"type:chart", "type"=>2}],
@@ -31,12 +32,12 @@ RSpec.describe Superset::Chart::UpdateDataset do
 
   let(:response) do
     {
-      "id"=>226,
+      "id"=>chart_id,
       "result"=>
        {
           "datasource_id"=>242,
           "datasource_type"=>"table",
-          "owners"=>[22, 104],
+          "owners"=>[9],
           "params"=>
           "{\"datasource\":\"242__table\",\"viz_type\":\"table\",\"slice_id\":54738,\"query_mode\":\"raw\",\"groupby\":[],\"time_grain_sqla\":\"P1D\",\"temporal_columns_lookup\":{\"started_on\":true,\"job_ended_on\":true,\"centrelink_outcome_started_on\":true},\"all_columns\":[\"started_on\",\"job_ended_on\",\"job_title\",\"company_name\"],\"percent_metrics\":[],\"adhoc_filters\":[{\"clause\":\"WHERE\",\"comparator\":\"No filter\",\"expressionType\":\"SIMPLE\",\"operator\":\"TEMPORAL_RANGE\",\"subject\":\"started_on\"}],\"order_by_cols\":[],\"row_limit\":50,\"server_page_length\":10,\"order_desc\":true,\"table_timestamp_format\":\"smart_date\",\"show_cell_bars\":true,\"color_pn\":true,\"extra_form_data\":{},\"dashboards\":[122]}",
           "query_context"=>
@@ -49,6 +50,11 @@ RSpec.describe Superset::Chart::UpdateDataset do
 
   before do
     allow(subject).to receive(:response).and_return(response)
+    allow(chart).to receive(:response).and_return(chart_response)
+    allow(chart).to receive(:owner_ids).and_return([9])
+    allow(chart).to receive(:datasource_id).and_return(243)
+    allow(chart).to receive(:params).and_return(JSON.parse(chart_response['params']))
+    allow(chart).to receive(:query_context).and_return(JSON.parse(chart_response['query_context']))
     allow(subject).to receive(:chart).and_return(chart)
   end
 

--- a/spec/superset/dashboard/copy_spec.rb
+++ b/spec/superset/dashboard/copy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Superset::Dashboard::Copy do
-  subject { described_class.new(id: dashboard_id, duplicate_slices: dup_slices) }
+  subject { described_class.new(source_dashboard_id: dashboard_id, duplicate_slices: dup_slices) }
   let(:dashboard_id) { 1 }
   let(:dup_slices) { true }
 
@@ -23,28 +23,28 @@ RSpec.describe Superset::Dashboard::Copy do
   describe 'perform' do
     context 'with valid params' do
       it 'returns the new dashboard id' do
-        expect(subject.perform).to eq(2)
+        expect(subject.perform).to be_an_instance_of(described_class)
       end
     end
 
     context 'with invalid params' do
-      context 'when id is not an integer' do
+      context 'when source_dashboard_id is not an integer' do
         let(:dashboard_id) { 'q' }
         
         it 'raises an error' do
-          expect { subject.perform }.to raise_error("Error: id integer is required")
+          expect { subject.perform }.to raise_error("Error: source_dashboard_id integer is required")
         end
       end
 
-      context 'when id is not present' do
+      context 'when source_dashboard_id is not present' do
         let(:dashboard_id) { nil }
         
         it 'raises an error' do
-          expect { subject.perform }.to raise_error("Error: id integer is required")
+          expect { subject.perform }.to raise_error("Error: source_dashboard_id integer is required")
         end
       end
 
-      context 'when id duplicate_slices not a boolean' do
+      context 'when source_dashboard_id duplicate_slices not a boolean' do
         let(:dup_slices) { 'q' }
         
         it 'raises an error' do

--- a/spec/superset/dashboard/datasets/list_spec.rb
+++ b/spec/superset/dashboard/datasets/list_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe Superset::Dashboard::Datasets::List do
   let(:result) do
     [
       {
-        id: 101,
-        datasource_name: 'Acme Forecasts',
-        database: { id: 1, name: 'DB1', backend: 'postgres' },
-        schema: 'acme'
-      },
+        'id' => 101,
+        'datasource_name' => 'Acme Forecasts',
+        'database' => { 'id' => 1, 'name' => 'DB1', 'backend' => 'postgres' },
+        'schema' => 'acme'
+      }.with_indifferent_access,
       {
-        id: 102,
-        datasource_name: 'video_game_sales',
-        database: { id: 2, name: 'examples', backend: 'postgres' },
-        schema: 'public'
-      }
+        'id' => 102,
+        'datasource_name' => 'video_game_sales',
+        'database' => { 'id' => 2, 'name' => 'examples', 'backend' => 'postgres' },
+        'schema' => 'public'
+      }.with_indifferent_access
     ]
   end
 
@@ -28,6 +28,7 @@ RSpec.describe Superset::Dashboard::Datasets::List do
   describe '#schemas' do
     context 'when the dashboard has dastasets from multiple schemas' do
       it 'returns a list of schemas' do
+
         expect(subject.schemas).to eq(['acme', 'public'])
       end
 
@@ -51,6 +52,15 @@ RSpec.describe Superset::Dashboard::Datasets::List do
         expect(Rollbar).to_not receive(:error)
         subject.schemas
       end
+    end
+  end
+
+  describe '#datasets_details' do
+    it 'returns a list of datasets' do
+      expect(subject.datasets_details).to eq([
+        {"id"=>101, "datasource_name"=>"Acme Forecasts", "schema"=>"acme", "database"=>{"id"=>1, "name"=>"DB1", "backend"=>"postgres"}},
+        {"id"=>102, "datasource_name"=>"video_game_sales", "schema"=>"public", "database"=>{"id"=>2, "name"=>"examples", "backend"=>"postgres"}}
+      ])
     end
   end
 

--- a/spec/superset/dataset/update_schema_spec.rb
+++ b/spec/superset/dataset/update_schema_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe Superset::Dataset::UpdateSchema do
 
   before do
     allow(subject).to receive(:response).and_return(response)
-    #allow(subject).to receive(:result).and_return(result)
     allow(subject).to receive(:source_dataset).and_return(source_dataset['result'])
     allow(subject).to receive(:target_database_available_schemas).and_return(target_database_available_schemas)
   end

--- a/spec/superset/services/duplicate_dashboard_spec.rb
+++ b/spec/superset/services/duplicate_dashboard_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'superset/services/duplicate_dashboard'
+
+RSpec.describe Superset::Services::DuplicateDashboard do
+  subject { described_class.new(
+              source_dashboard_id: source_dashboard_id, 
+              target_schema:       target_schema, 
+              target_database_id:  target_database_id) }
+  
+  let(:source_dashboard_id) { 1 }
+  let(:target_schema) { 'schema_one' }
+  let(:target_database_id) { 6 }
+  let(:target_database_available_schemas) { ['schema_one', 'schema_two', 'schema_three'] }
+
+  let(:new_dashboard) { double('new_dashboard', id: 2) }
+
+  before do
+    allow(subject).to receive(:target_database_available_schemas).and_return(target_database_available_schemas)
+    allow(subject).to receive(:new_dashboard).and_return(new_dashboard)
+  end
+
+  describe '#perform' do
+    context 'with valid params' do
+
+
+    end
+
+    context 'with invalid params' do
+      context 'source_dashboard_id is empty' do
+        let(:source_dashboard_id) { nil }
+        
+        specify do
+          expect { subject.perform }.to raise_error(RuntimeError, "Error: source_dashboard_id integer is required")
+        end
+      end
+  
+      context 'target_schema is empty' do
+        let(:target_schema) { nil }
+
+        specify do
+          expect { subject.perform }.to raise_error(RuntimeError, "Error: target_schema string is required")
+        end
+      end
+
+      context 'target_database_id is empty' do
+        let(:target_database_id) { nil }
+        
+        specify do
+          expect { subject.perform }.to raise_error(RuntimeError, "Error: target_database_id integer is required")
+        end
+      end
+
+      context 'target_schema is invalid' do
+        let(:target_schema) { 'schema_four' }
+
+        specify do
+          expect { subject.perform }.to raise_error(RuntimeError, "Error: Schema schema_four does not exist in target database: 6")
+        end
+      end
+
+      context 'source dashboard datasets use multiple schemas' do
+        before do
+          allow(subject).to receive(:source_dashboard_schemas).and_return(['schema_one', 'schema_five'])
+        end
+   
+        specify do
+          expect { subject.perform }.to raise_error(RuntimeError, "Error: The souce_dashboard_id #{source_dashboard_id} datasets point to more than one schema. Schema list is schema_one,schema_five")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jobready.atlassian.net/browse/NEP-17487


**DuplcateDashboard process:**

Given a source dashboard, and a target schema and database:
- duplicate the Dashboard and layout
- duplicate all Charts
- duplicate all Dataset point to the new target scheam and database

NOTE: Filter duplication will be in a separate PR

This Superset Dashboard is on JobReady Staging tenant
https://staging.ready-superset.jobready.io/superset/dashboard/174

Run the following command to point to `jobready_stage_demo' tenant.


```
Superset::Services::DuplicateDashboard.new(
  source_dashboard_id: 174, 
  target_schema: 'jobready_stage_demo', 
  target_database_id: 7).perform


```

Note that running a second time will raise and error
`Error: new_dataset_name already in use`
as within a Database Schema, ie jobready_stage_demo` the dataset names must be uniq.

Fix is to clean up after yourself and 
- delete the new copied dashboard ( may fail with an error in the SS GUI, core SS error)
- delete the new charts
- delete the new dataset 
Then you could rerun the command.

