### PR TITLE
[NEP-19106]: Fix embedding logic in superset client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+## 0.2.4 - 2025-01-29
+* modifies the `Superset::Dashboard::Datasets::List.new(id).schemas` to optionally include filter datasets as well.
+* modifies the `Superset::Dashboard::Embedded::Get.new` to accept dashboard_id as named parameter
+* modifies the `Superset::Dashboard::List.new().retrieve_schemas` to call `Datasets::List.new(dashboard_id: id, include_filter_datasets: true).schemas` with `include_filter_datasets` to validate the filter dataset schemas during dashboard embedding.
+
+
 ## 0.2.3 - 2024-11-15
 
 * modifies the `Superset::Dashboard::Datasets::List.new(id).dataset_details` and `Superset::Dashboard::Datasets::List.new(id).list` to optionally include filter datasets as well to duplicate those during the dashboard duplication process. It also add a new column "Filter only" in the result which shows if a dataset is used only on filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.2.4 - 2025-01-29
 * modifies the `Superset::Dashboard::Datasets::List.new(id).schemas` to optionally include filter datasets as well.
 * modifies the `Superset::Dashboard::Embedded::Get.new` to accept dashboard_id as named parameter
-* modifies the `Superset::Dashboard::List.new().retrieve_schemas` to call `Datasets::List.new(dashboard_id: id, include_filter_datasets: true).schemas` with `include_filter_datasets` to validate the filter dataset schemas during dashboard embedding.
+* modifies the `Superset::Dashboard::List.new()` to accept an additional named parameter `include_filter_dataset_schemas` to decide whether filter datasets needs to be included when getting the schemas of the datasets
+* modifies the `Superset::Dashboard::List.new().retrieve_schemas` to call `Datasets::List.new(dashboard_id: id).schemas` with an additional parameter `include_filter_datasets` to fetch the filter dataset schemas as well.
 
 
 ## 0.2.3 - 2024-11-15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    superset (0.2.3)
+    superset (0.2.4)
       dotenv (~> 2.7)
       enumerate_it (~> 1.7.0)
       faraday (~> 1.0)

--- a/lib/superset/dashboard/datasets/list.rb
+++ b/lib/superset/dashboard/datasets/list.rb
@@ -25,7 +25,7 @@ module Superset
 
         def schemas
           @schemas ||= begin
-            all_dashboard_schemas = result.map {|d| d[:schema] }.uniq
+            all_dashboard_schemas = datasets_details.map {|d| d[:schema] }.uniq
 
             # For the current superset setup we will assume a dashboard datasets will point to EXACTLY one schema, their own.
             # if not .. we need to know about it. Potentially we could override this check if others do not consider it a problem.

--- a/lib/superset/dashboard/embedded/get.rb
+++ b/lib/superset/dashboard/embedded/get.rb
@@ -8,8 +8,8 @@ module Superset
           self.new(id).list
         end
 
-        def initialize(id)
-          @id = id
+        def initialize(dashboard_id:)
+          @id = dashboard_id
         end
 
         def response

--- a/lib/superset/dashboard/list.rb
+++ b/lib/superset/dashboard/list.rb
@@ -35,7 +35,7 @@ module Superset
       end
 
       def retrieve_schemas(id)
-        { schemas: Datasets::List.new(id).schemas }
+        { schemas: Datasets::List.new(dashboard_id: id, include_filter_datasets: true).schemas }
       rescue StandardError => e
         # within Superset, a bug exists around deleting dashboards failing and the corrupting datasets configs, so handle errored datasets gracefully
         # ref NEP-17532
@@ -43,7 +43,7 @@ module Superset
       end
 
       def retrieve_embedded_details(id)
-        embedded_dashboard = Dashboard::Embedded::Get.new(id)
+        embedded_dashboard = Dashboard::Embedded::Get.new(dashboard_id: id)
         { allowed_embedded_domains: embedded_dashboard.allowed_domains,
           uuid: embedded_dashboard.uuid,}
       end

--- a/lib/superset/dashboard/list.rb
+++ b/lib/superset/dashboard/list.rb
@@ -5,13 +5,14 @@
 module Superset
   module Dashboard
     class List < Superset::Request
-      attr_reader :title_contains, :title_equals, :tags_equal, :ids_not_in
+      attr_reader :title_contains, :title_equals, :tags_equal, :ids_not_in, :include_filter_dataset_schemas
 
-      def initialize(page_num: 0, title_contains: '', title_equals: '', tags_equal: [], ids_not_in: [])
+      def initialize(page_num: 0, title_contains: '', title_equals: '', tags_equal: [], ids_not_in: [], include_filter_dataset_schemas: false)
         @title_contains = title_contains
         @title_equals = title_equals
         @tags_equal = tags_equal
         @ids_not_in = ids_not_in
+        @include_filter_dataset_schemas = include_filter_dataset_schemas
         super(page_num: page_num)
       end
 
@@ -35,7 +36,7 @@ module Superset
       end
 
       def retrieve_schemas(id)
-        { schemas: Datasets::List.new(dashboard_id: id, include_filter_datasets: true).schemas }
+        { schemas: Datasets::List.new(dashboard_id: id, include_filter_datasets: include_filter_dataset_schemas).schemas }
       rescue StandardError => e
         # within Superset, a bug exists around deleting dashboards failing and the corrupting datasets configs, so handle errored datasets gracefully
         # ref NEP-17532

--- a/lib/superset/version.rb
+++ b/lib/superset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Superset
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/superset/dashboard/embedded/get_spec.rb
+++ b/spec/superset/dashboard/embedded/get_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Superset::Dashboard::Embedded::Get, type: :service do
-  subject { described_class.new(dashboard_id) }
+  subject { described_class.new(dashboard_id: dashboard_id) }
   let(:dashboard_id) { 1 }
 
   describe 'with a dashboard that has embedded settings, ie has a result' do


### PR DESCRIPTION
https://jobready.atlassian.net/browse/NEP-19106

This ticket,
* modifies the `Superset::Dashboard::Datasets::List.new(id).schemas` to optionally include filter datasets as well.
* modifies the `Superset::Dashboard::Embedded::Get.new` to accept dashboard_id as named parameter
* modifies the `Superset::Dashboard::List.new()` to accept an additional named parameter `include_filter_dataset_schemas` to decide whether filter datasets needs to be included when getting the schemas of the datasets
* modifies the `Superset::Dashboard::List.new().retrieve_schemas` to call `Datasets::List.new(dashboard_id: id).schemas` with an additional parameter `include_filter_datasets` to fetch the filter dataset schemas as well.