### PR TITLE
make dashboard import handle directories in addition to zips

### DIFF
--- a/doc/migrating_dashboards_across_environments.md
+++ b/doc/migrating_dashboards_across_environments.md
@@ -20,12 +20,12 @@ Assuming your API env for ruby is setup for your target superset environment.
 
 new_import_zip = Superset::Services::ImportDashboardAcrossEnvironments.new(
   dashboard_export_zip:      'path_to/dashboard_101_export_20241010.zip',
-  target_database_yaml_file: 'path_to/env2_db_config.yaml', 
-  target_database_schema:    'acme', 
+  target_database_yaml_file: 'path_to/env2_db_config.yaml',
+  target_database_schema:    'acme',
   ).perform
 
 # now import the adjusted zip to the target superset env
-Superset::Dashboard::Import.new(source_zip_file: new_import_file).perform
+Superset::Dashboard::Import.new(source: new_import_file).perform
 
 ```
 

--- a/lib/superset/dashboard/import.rb
+++ b/lib/superset/dashboard/import.rb
@@ -1,29 +1,32 @@
-# Import the provided Dashboard zip file
+# frozen_string_literal: true
+
+# Import the provided Dashboard zip file or directory (aka source)
 # In the context of this API import process, assumption is that the database.yaml file details will match
 # an existing database in the Target Superset Environment.
 
 # Scenario 1: Export from Env1 -- Import to Env1 into the SAME Environment
-#             Will result in updating/over writing the dashboard with the contents of the zip file 
+#             Will result in updating/over writing the dashboard with the contents of the source
 
 # Scenario 2: Export from Env1 -- Import to Env2 into a DIFFERENT Environment
-#             Assumption is that the database.yaml will match a database configuration in the target env. 
-#             Initial import will result in creating a new dashboard with the contents of the zip file. 
-#             Subsequent imports will result in updating/over writing the previous imported dashboard with the contents of the zip file.
+#             Assumption is that the database.yaml will match a database configuration in the target env.
+#             Initial import will result in creating a new dashboard with the contents of the source.
+#             Subsequent imports will result in updating/over writing the previous imported dashboard with the contents of the source.
 
 # the overwrite flag will determine if the dashboard will be updated or created new
 # overwrite: false .. will result in an error if a dashboard with the same UUID already exists
 
 # Usage
-# Superset::Dashboard::Import.new(source_zip_file: '/tmp/dashboard.zip').perform
+# Superset::Dashboard::Import.new(source: '/tmp/dashboard.zip').perform
+# Superset::Dashboard::Import.new(source: '/tmp/dashboard').perform
 #
 
 module Superset
   module Dashboard
     class Import < Request
-      attr_reader :source_zip_file, :overwrite
+      attr_reader :source, :overwrite
 
-      def initialize(source_zip_file: , overwrite: true)
-        @source_zip_file = source_zip_file
+      def initialize(source:, overwrite: true)
+        @source = source
         @overwrite = overwrite
       end
 
@@ -42,16 +45,20 @@ module Superset
       private
 
       def validate_params
-        raise ArgumentError, 'source_zip_file is required' if source_zip_file.nil?
-        raise ArgumentError, 'source_zip_file does not exist' unless File.exist?(source_zip_file)
-        raise ArgumentError, 'source_zip_file is not a zip file' unless File.extname(source_zip_file) == '.zip'
-        raise ArgumentError, 'overwrite must be a boolean' unless [true, false].include?(overwrite)
-        raise ArgumentError, "zip target database does not exist: #{zip_database_config_not_found_in_superset}" if zip_database_config_not_found_in_superset.present?
+        raise ArgumentError, "source is required" if source.nil?
+        raise ArgumentError, "source does not exist" unless File.exist?(source)
+        raise ArgumentError, "source is not a zip file or directory" unless zip? || directory?
+        raise ArgumentError, "overwrite must be a boolean" unless [true, false].include?(overwrite)
+
+        return unless database_config_not_found_in_superset.present?
+
+        raise ArgumentError,
+              "target database does not exist: #{database_config_not_found_in_superset}"
       end
 
       def payload
         {
-          formData: Faraday::UploadIO.new(source_zip_file, 'application/zip'),
+          formData: Faraday::UploadIO.new(source_zip_file, "application/zip"),
           overwrite: overwrite.to_s
         }
       end
@@ -60,24 +67,56 @@ module Superset
         "dashboard/import/"
       end
 
-      def zip_database_config_not_found_in_superset
-        zip_databases_details.select {|s| !superset_database_uuids_found.include?(s[:uuid]) }
+      def zip?
+        File.extname(source) == ".zip"
+      end
+
+      def directory?
+        File.directory?(source)
+      end
+
+      def source_zip_file
+        return source if zip?
+
+        Zip::File.open(new_zip_file, Zip::File::CREATE) do |zipfile|
+          Dir[File.join(source, "**", "**")].each do |file|
+            zipfile.add(file.sub("#{source}/", "#{File.basename(source)}/"), file) if File.file?(file)
+          end
+        end
+        new_zip_file
+      end
+
+      def new_zip_file
+        new_database_name = dashboard_config[:databases].first[:content][:database_name]
+        File.join(source, "dashboard_import.zip")
+      end
+
+      def database_config_not_found_in_superset
+        databases_details.reject { |s| superset_database_uuids_found.include?(s[:uuid]) }
       end
 
       def superset_database_uuids_found
-        @superset_database_uuids_found ||= begin
-          zip_databases_details.map {|i| i[:uuid]}.map do |uuid|
-            uuid if Superset::Database::List.new(uuid_equals: uuid).result.present?
-          end.compact
-        end
+        @superset_database_uuids_found ||= databases_details.map { |i| i[:uuid] }.map do |uuid|
+          uuid if Superset::Database::List.new(uuid_equals: uuid).result.present?
+        end.compact
       end
 
-      def zip_databases_details
-        zip_dashboard_config[:databases].map{|d| {uuid: d[:content][:uuid], name: d[:content][:database_name]} }
+      def databases_details
+        dashboard_config[:databases].map { |d| { uuid: d[:content][:uuid], name: d[:content][:database_name] } }
+      end
+
+      def dashboard_config
+        @dashboard_config ||= zip? ? zip_dashboard_config : directory_dashboard_config
       end
 
       def zip_dashboard_config
-        @zip_dashboard_config ||= Superset::Services::DashboardLoader.new(dashboard_export_zip: source_zip_file).perform
+        Superset::Services::DashboardLoader.new(dashboard_export_zip: source).perform
+      end
+
+      def directory_dashboard_config
+        Superset::Services::DashboardLoader::DashboardConfig.new(
+          dashboard_export_zip: "", tmp_uniq_dashboard_path: source
+        ).config
       end
     end
   end

--- a/lib/superset/dashboard/import.rb
+++ b/lib/superset/dashboard/import.rb
@@ -80,15 +80,25 @@ module Superset
 
         Zip::File.open(new_zip_file, Zip::File::CREATE) do |zipfile|
           Dir[File.join(source, "**", "**")].each do |file|
-            zipfile.add(file.sub("#{source}/", "#{File.basename(source)}/"), file) if File.file?(file)
+            next unless File.file?(file)
+
+            # add a base folder to the relative path: "dashboard_import_#{timestamp}"
+            zipfile.add(File.join("dashboard_import_#{timestamp}", relative_path(file)), file)
           end
         end
         new_zip_file
       end
 
+      def relative_path(file)
+        Pathname.new(file).relative_path_from(Pathname.new(source)).to_s
+      end
+
       def new_zip_file
-        new_database_name = dashboard_config[:databases].first[:content][:database_name]
-        File.join(source, "dashboard_import.zip")
+        File.join(source, "dashboard_import_#{timestamp}.zip")
+      end
+
+      def timestamp
+        @timestamp ||= Time.now.strftime("%Y%m%d%H%M%S")
       end
 
       def database_config_not_found_in_superset

--- a/spec/superset/dashboard/import_spec.rb
+++ b/spec/superset/dashboard/import_spec.rb
@@ -1,76 +1,284 @@
-require 'spec_helper'
-require 'superset/dashboard/import'
+# frozen_string_literal: true
+
+require "spec_helper"
+require "superset/dashboard/import"
+require "zip"
 
 RSpec.describe Superset::Dashboard::Import do
-  describe '#perform' do
-    context 'when the source zip file exists' do
-      let(:subject) { described_class.new(source_zip_file: source_zip_file, overwrite: overwrite) }
-      let(:source_zip_file) { 'spec/fixtures/dashboard_18_export_20240322.zip' }
+  describe "#perform" do
+    context "when the source is a directory" do
+      let(:subject) { described_class.new(source: source, overwrite: overwrite) }
+      let(:source) do
+        root_dir = File.expand_path("#{__dir__}/../../..")
+        tmp_dir = "#{root_dir}/tmp"
+        FileUtils.mkdir_p(tmp_dir)
+
+        Zip::File.open("#{root_dir}/spec/fixtures/dashboard_18_export_20240322.zip") do |zip_file|
+          zip_file.each do |f|
+            fpath = File.join(tmp_dir, f.name)
+            FileUtils.mkdir_p(File.dirname(fpath))
+            zip_file.extract(f, fpath) unless File.exist?(fpath)
+          end
+        end
+        "#{tmp_dir}/dashboard_export_20240321T214117"
+      end
       let(:overwrite) { true }
 
       let(:response) { { "result": "true" } }
 
       before { allow(subject).to receive(:response).and_return(response) }
 
-      describe '#response' do
-        context 'with valid parameters' do
+      describe "#response" do
+        context "with valid parameters" do
           before do
-            allow(Superset::Database::List).to receive(:new).
-              with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee").
-              and_return(double(result: ['some data']))
+            allow(Superset::Database::List).to receive(:new)
+              .with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee")
+              .and_return(double(result: ["some data"]))
           end
 
-          specify 'returns response' do
+          specify "returns response" do
             expect(subject.perform).to eq(response)
           end
         end
 
-        context 'with invalid parameters' do
+        context "when source file does not exist" do
+          let(:source) { "./test" }
 
-          context 'when source zip file is nil' do
-            let(:source_zip_file) { nil }
+          specify "raises error" do
+            expect { subject.perform }.to raise_error(ArgumentError, "source does not exist")
+          end
+        end
 
-            specify 'raises error' do
-              expect { subject.perform }.to raise_error(ArgumentError, 'source_zip_file is required')
+        context "when database_config_not_found_in_superset is not present" do
+          before do
+            allow(Superset::Database::List).to receive(:new)
+              .with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee")
+              .and_return(double(result: []))
+          end
+
+          specify "raises error" do
+            expect do
+              subject.perform
+            end.to raise_error(ArgumentError,
+                               "target database does not exist: [{:uuid=>\"a2dc77af-e654-49bb-b321-40f6b559a1ee\", :name=>\"examples\"}]")
+          end
+        end
+      end
+    end
+    context "when the source zip file exists" do
+      let(:subject) { described_class.new(source: source, overwrite: overwrite) }
+      let(:source) { "spec/fixtures/dashboard_18_export_20240322.zip" }
+      let(:overwrite) { true }
+
+      let(:response) { { "result": "true" } }
+
+      before { allow(subject).to receive(:response).and_return(response) }
+
+      describe "#response" do
+        context "with valid parameters" do
+          before do
+            allow(Superset::Database::List).to receive(:new)
+              .with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee")
+              .and_return(double(result: ["some data"]))
+          end
+
+          specify "returns response" do
+            expect(subject.perform).to eq(response)
+          end
+        end
+
+        context "with invalid parameters" do
+          context "when source zip file is nil" do
+            let(:source) { nil }
+
+            specify "raises error" do
+              expect { subject.perform }.to raise_error(ArgumentError, "source is required")
             end
           end
 
-          context 'when source file does not exist' do
-            let(:source_zip_file) { './test.zip' }
+          context "when source file does not exist" do
+            let(:source) { "./test.zip" }
 
-            specify 'raises error' do
-              expect { subject.perform }.to raise_error(ArgumentError, 'source_zip_file does not exist')
+            specify "raises error" do
+              expect { subject.perform }.to raise_error(ArgumentError, "source does not exist")
             end
           end
 
-          context 'when overwrite is not a boolean' do
-            let(:overwrite) { 'blah' }
+          context "when overwrite is not a boolean" do
+            let(:overwrite) { "blah" }
 
-            specify 'raises error' do
-              expect { subject.perform }.to raise_error(ArgumentError, 'overwrite must be a boolean')
+            specify "raises error" do
+              expect { subject.perform }.to raise_error(ArgumentError, "overwrite must be a boolean")
             end
           end
 
-          context 'when source_zip_file is not a zip extension' do
-            let(:source_zip_file) { 'spec/fixtures/database-prod-examples.yaml' }
+          context "when source is not a zip extension" do
+            let(:source) { "spec/fixtures/database-prod-examples.yaml" }
 
-            specify 'raises error' do
-              expect { subject.perform }.to raise_error(ArgumentError, 'source_zip_file is not a zip file')
+            specify "raises error" do
+              expect { subject.perform }.to raise_error(ArgumentError, "source is not a zip file or directory")
             end
           end
 
-          context 'when zip_database_config_not_found_in_superset is not present' do
+          context "when database_config_not_found_in_superset is not present" do
             before do
-              allow(Superset::Database::List).to receive(:new).
-                with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee").
-                and_return(double(result: []))
+              allow(Superset::Database::List).to receive(:new)
+                .with(uuid_equals: "a2dc77af-e654-49bb-b321-40f6b559a1ee")
+                .and_return(double(result: []))
             end
 
-            specify 'raises error' do
-              expect { subject.perform }.to raise_error(ArgumentError, "zip target database does not exist: [{:uuid=>\"a2dc77af-e654-49bb-b321-40f6b559a1ee\", :name=>\"examples\"}]")
+            specify "raises error" do
+              expect do
+                subject.perform
+              end.to raise_error(ArgumentError,
+                                 "target database does not exist: [{:uuid=>\"a2dc77af-e654-49bb-b321-40f6b559a1ee\", :name=>\"examples\"}]")
             end
           end
         end
+      end
+    end
+  end
+
+  describe "#source_zip_file" do
+    let(:subject) { described_class.new(source: source, overwrite: true) }
+
+    context "when source is already a zip file" do
+      let(:source) { "spec/fixtures/dashboard_18_export_20240322.zip" }
+
+      before do
+        allow(File).to receive(:extname).with(source).and_return(".zip")
+      end
+
+      it "returns the source path unchanged" do
+        expect(subject.send(:source_zip_file)).to eq(source)
+      end
+    end
+
+    context "when source is a directory" do
+      let(:source) { "spec/fixtures/dashboard_export_20240321T214117" }
+      let(:new_zip_file) { "#{source}/dashboard_import.zip" }
+      let(:dashboard_config) do
+        {
+          databases: [
+            {
+              content: {
+                database_name: "examples"
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(File).to receive(:extname).with(source).and_return("")
+        allow(File).to receive(:directory?).with(source).and_return(true)
+        allow(subject).to receive(:dashboard_config).and_return(dashboard_config)
+        allow(subject).to receive(:new_zip_file).and_return(new_zip_file)
+
+        # Mock Zip::File.open to prevent actual zip creation
+        zip_file_double = double("Zip::File")
+        allow(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE).and_yield(zip_file_double)
+        allow(zip_file_double).to receive(:add)
+
+        # Mock Dir[] to return a list of files
+        allow(Dir).to receive(:[]).with(File.join(source, "**", "**")).and_return(
+          ["#{source}/file1.yaml", "#{source}/subdirectory/file2.yaml"]
+        )
+
+        # Mock File.file? to simulate real files
+        allow(File).to receive(:file?).and_return(true)
+      end
+
+      it "creates a zip file and returns its path" do
+        expect(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE)
+        expect(subject.send(:source_zip_file)).to eq(new_zip_file)
+      end
+
+      it "adds directory content to the zip file" do
+        zip_file_double = double("Zip::File")
+        expect(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE).and_yield(zip_file_double)
+        expect(zip_file_double).to receive(:add).with(
+          "dashboard_export_20240321T214117/file1.yaml", "#{source}/file1.yaml"
+        )
+        expect(zip_file_double).to receive(:add).with(
+          "dashboard_export_20240321T214117/subdirectory/file2.yaml", "#{source}/subdirectory/file2.yaml"
+        )
+
+        subject.send(:source_zip_file)
+      end
+    end
+
+    context "integration between source_zip_file and new_zip_file methods" do
+      let(:source) { "spec/fixtures/dashboard_export_20240321T214117" }
+      let(:dashboard_config) do
+        {
+          databases: [
+            {
+              content: {
+                database_name: "custom_database"
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(File).to receive(:extname).with(source).and_return("")
+        allow(File).to receive(:directory?).with(source).and_return(true)
+        allow(subject).to receive(:dashboard_config).and_return(dashboard_config)
+
+        # Skip actual zip creation
+        zip_file_double = double("Zip::File")
+        allow(Zip::File).to receive(:open).and_yield(zip_file_double)
+        allow(zip_file_double).to receive(:add)
+        allow(Dir).to receive(:[]).and_return([])
+      end
+
+      it "creates a zip file in the source directory" do
+        expected_path = "#{source}/dashboard_import.zip"
+        expect(subject.send(:source_zip_file)).to eq(expected_path)
+      end
+    end
+
+    context "when source is neither a zip file nor a directory" do
+      let(:source) { "spec/fixtures/some_invalid_file.txt" }
+
+      before do
+        allow(File).to receive(:extname).with(source).and_return(".txt")
+        allow(File).to receive(:directory?).with(source).and_return(false)
+        allow(File).to receive(:exist?).with(source).and_return(true)
+      end
+
+      it "raises an error during validation" do
+        expect { subject.perform }.to raise_error(ArgumentError, "source is not a zip file or directory")
+      end
+    end
+  end
+
+  describe "#new_zip_file" do
+    let(:subject) { described_class.new(source: source, overwrite: true) }
+    let(:source) { "spec/fixtures/dashboard_export_20240321T214117" }
+
+    context "when dashboard config has databases" do
+      let(:dashboard_config) do
+        {
+          databases: [
+            {
+              content: {
+                database_name: "test_database"
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(subject).to receive(:dashboard_config).and_return(dashboard_config)
+      end
+
+      it "creates a zip file path using the source directory" do
+        expected_path = "#{source}/dashboard_import.zip"
+        expect(subject.send(:new_zip_file)).to eq(expected_path)
       end
     end
   end

--- a/spec/superset/dashboard/import_spec.rb
+++ b/spec/superset/dashboard/import_spec.rb
@@ -197,11 +197,12 @@ RSpec.describe Superset::Dashboard::Import do
       it "adds directory content to the zip file" do
         zip_file_double = double("Zip::File")
         expect(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE).and_yield(zip_file_double)
+
         expect(zip_file_double).to receive(:add).with(
-          "dashboard_export_20240321T214117/file1.yaml", "#{source}/file1.yaml"
+          "dashboard_import_#{subject.send(:timestamp)}/file1.yaml", "#{source}/file1.yaml"
         )
         expect(zip_file_double).to receive(:add).with(
-          "dashboard_export_20240321T214117/subdirectory/file2.yaml", "#{source}/subdirectory/file2.yaml"
+          "dashboard_import_#{subject.send(:timestamp)}/subdirectory/file2.yaml", "#{source}/subdirectory/file2.yaml"
         )
 
         subject.send(:source_zip_file)
@@ -235,7 +236,7 @@ RSpec.describe Superset::Dashboard::Import do
       end
 
       it "creates a zip file in the source directory" do
-        expected_path = "#{source}/dashboard_import.zip"
+        expected_path = "#{source}/dashboard_import_#{subject.send(:timestamp)}.zip"
         expect(subject.send(:source_zip_file)).to eq(expected_path)
       end
     end
@@ -277,7 +278,7 @@ RSpec.describe Superset::Dashboard::Import do
       end
 
       it "creates a zip file path using the source directory" do
-        expected_path = "#{source}/dashboard_import.zip"
+        expected_path = "#{source}/dashboard_import_#{subject.send(:timestamp)}.zip"
         expect(subject.send(:new_zip_file)).to eq(expected_path)
       end
     end


### PR DESCRIPTION
Expands the dashboard importer to handle directories instead of requiring it to be fed zips.