### PR TITLE
Nep 19678 add dataset refresh endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+## 0.2.5 - 2025-05-22
+* add refresh dataset call in `Superset::Dataset::Refresh.call(id)`
+
 ## 0.2.4 - 2025-01-29
 * modifies the `Superset::Dashboard::Datasets::List.new(id).schemas` to optionally include filter datasets as well.
 * modifies the `Superset::Dashboard::Embedded::Get.new` to accept dashboard_id as named parameter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    superset (0.2.4)
+    superset (0.2.5)
       dotenv (~> 2.7)
       enumerate_it (~> 1.7.0)
       faraday (~> 1.0)

--- a/lib/superset/dataset/refresh.rb
+++ b/lib/superset/dataset/refresh.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Description: Same functionality as 'Sync Columns from Source' button in the Superset UI on a dataset.
+# Executes the dataset against the source to confirm query run and sync and cache dataset columns for charting.
+# Usage: Superset::Dataset::Refresh.call(id)
+
 module Superset
   module Dataset
     class Refresh < Superset::Request

--- a/lib/superset/dataset/refresh.rb
+++ b/lib/superset/dataset/refresh.rb
@@ -2,6 +2,8 @@
 
 # Description: This endpoint has the same functionality as 'Sync Columns from Source' button in the Superset UI on a dataset.
 # Executes the dataset against the source to confirm the query runs and then sync and cache dataset columns.
+# NOTICE: only owners of the dataset can refresh it
+#
 # Usage: Superset::Dataset::Refresh.call(id)
 
 module Superset

--- a/lib/superset/dataset/refresh.rb
+++ b/lib/superset/dataset/refresh.rb
@@ -1,0 +1,30 @@
+module Superset
+  module Dataset
+    class Refresh < Superset::Request
+
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      def self.call(id)
+        self.new(id).perform
+      end
+
+      def perform
+        response
+      end
+
+      def response
+        @response ||= client.put(route)
+      end
+
+      private
+
+      def route
+        "dataset/#{id}/refresh"
+      end
+    end
+  end
+end

--- a/lib/superset/dataset/refresh.rb
+++ b/lib/superset/dataset/refresh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Description: Same functionality as 'Sync Columns from Source' button in the Superset UI on a dataset.
-# Executes the dataset against the source to confirm query run and sync and cache dataset columns for charting.
+# Description: This endpoint has the same functionality as 'Sync Columns from Source' button in the Superset UI on a dataset.
+# Executes the dataset against the source to confirm the query runs and then sync and cache dataset columns.
 # Usage: Superset::Dataset::Refresh.call(id)
 
 module Superset

--- a/lib/superset/version.rb
+++ b/lib/superset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Superset
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "superset/credential/embedded_user"
 require "superset/client"
 require "superset/display"
 require "superset/request"
+require "superset/base_put_request"
 
 Dir["./lib/**/*.rb"].each { |f| require f }
 

--- a/spec/superset/dataset/refresh_spec.rb
+++ b/spec/superset/dataset/refresh_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe Superset::Dataset::Refresh do
   subject { described_class.new(id) }
   let(:id) { 1 }
   let(:result) { { "message": "OK" } }
+  let(:client) { instance_double(Superset::Client) }
 
   before do
-    allow(subject).to receive(:response).and_return(result)
+    allow(subject).to receive(:client).and_return(client)
   end
 
   describe '.call' do
@@ -18,7 +19,15 @@ RSpec.describe Superset::Dataset::Refresh do
 
   describe '#perform' do
     specify do
+      expect(client).to receive(:put).with("dataset/#{id}/refresh").and_return(result)
       expect(subject.perform).to eq result
+    end
+  end
+
+  describe '#response' do
+    specify 'memoizes the response' do
+      expect(client).to receive(:put).with("dataset/#{id}/refresh").once.and_return(result)
+      2.times { subject.response }
     end
   end
 end

--- a/spec/superset/dataset/refresh_spec.rb
+++ b/spec/superset/dataset/refresh_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Superset::Dataset::Refresh do
+  subject { described_class.new(id) }
+  let(:id) { 1 }
+  let(:result) { { "message": "OK" } }
+
+  before do
+    allow(subject).to receive(:response).and_return(result)
+  end
+
+  describe '.call' do
+    specify do
+      expect_any_instance_of(described_class).to receive(:perform)
+      described_class.call(id)
+    end
+  end
+
+  describe '#perform' do
+    specify do
+      expect(subject.perform).to eq result
+    end
+  end
+end


### PR DESCRIPTION
https://jobready.atlassian.net/browse/NEP-19678

Adds class to hit the dataset refresh endpoint

```
# Description: This endpoint has the same functionality as 'Sync Columns from Source' button in the Superset UI on a dataset.
# Executes the dataset against the source to confirm the query runs and then sync and cache dataset columns.
# Usage: Superset::Dataset::Refresh.call(id)
```