### PR TITLE
[NEP-19833]: Fetching normal and shared datasets separately

### DIFF
--- a/lib/superset/dashboard/bulk_delete_cascade.rb
+++ b/lib/superset/dashboard/bulk_delete_cascade.rb
@@ -9,10 +9,11 @@ module Superset
     class BulkDeleteCascade
       class InvalidParameterError < StandardError; end
 
-      attr_reader :dashboard_ids
+      attr_reader :dashboard_ids, :ignore_shared_datasets
 
-      def initialize(dashboard_ids: [])
+      def initialize(dashboard_ids: [], ignore_shared_datasets: false)
         @dashboard_ids = dashboard_ids
+        @ignore_shared_datasets = ignore_shared_datasets
       end
 
       def perform
@@ -31,7 +32,7 @@ module Superset
       private
 
       def delete_datasets(dashboard_id)
-        datasets_to_delete = Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).datasets_details.map{|d| d[:id] }
+        datasets_to_delete = Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id, separate_shared_datasets: ignore_shared_datasets).datasets_details["datasets"].map{|d| d[:id] }
         Superset::Dataset::BulkDelete.new(dataset_ids: datasets_to_delete).perform if datasets_to_delete.any?
       end
 

--- a/lib/superset/dashboard/compare.rb
+++ b/lib/superset/dashboard/compare.rb
@@ -37,8 +37,8 @@ module Superset
 
       def list_datasets
         puts "\n ====== DASHBOARD DATASETS ====== "
-        Superset::Dashboard::Datasets::List.new(dashboard_id: first_dashboard_id).list
-        Superset::Dashboard::Datasets::List.new(dashboard_id: second_dashboard_id).list
+        Superset::Dashboard::Datasets::List.new(dashboard_id: first_dashboard_id, include_filter_datasets: true).list
+        Superset::Dashboard::Datasets::List.new(dashboard_id: second_dashboard_id, include_filter_datasets: true).list
       end
 
       def list_charts

--- a/lib/superset/dashboard/warm_up_cache.rb
+++ b/lib/superset/dashboard/warm_up_cache.rb
@@ -35,7 +35,7 @@ module Superset
       end
 
       def fetch_dataset_details(dashboard_id)
-        Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).datasets_details.map { |dataset| dataset['database'].slice('name').merge(dataset.slice('datasource_name'))}
+        Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).datasets_details['datasets'].map { |dataset| dataset['database'].slice('name').merge(dataset.slice('datasource_name'))}
       end
     end
   end

--- a/spec/superset/dashboard/bulk_delete_cascade_spec.rb
+++ b/spec/superset/dashboard/bulk_delete_cascade_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Superset::Dashboard::BulkDeleteCascade do
       let(:dashboard_ids) { [1] }
 
       before do
-        allow(Superset::Dashboard::Datasets::List).to receive(:new).with(dashboard_id: 1).and_return(double(datasets_details: [{ id: 11 }, { id: 12 }]))
+        allow(Superset::Dashboard::Datasets::List).to receive(:new).with(dashboard_id: 1).and_return(double(datasets_details: {'datasets' => [{ id: 11 }, { id: 12 }] }))
         allow(Superset::Dataset::BulkDelete).to receive(:new).with(dataset_ids: [11,12]).and_return(double(perform: true))
 
         allow(Superset::Dashboard::Charts::List).to receive(:new).with(1).and_return(double(chart_ids: [21, 22]))

--- a/spec/superset/dashboard/datasets/list_spec.rb
+++ b/spec/superset/dashboard/datasets/list_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Superset::Dashboard::Datasets::List do
   let(:dashboard_id) { 1 }
   let(:include_filter_datasets) { false }
   let(:result) do
-    [
-      {
-        'id' => 101,
-        'datasource_name' => 'Acme Forecasts',
-        'database' => { 'id' => 1, 'name' => 'DB1', 'backend' => 'postgres' },
-        'schema' => 'acme',
+    {
+      'datasets' => [
+        {
+          'id' => 101,
+          'datasource_name' => 'Acme Forecasts',
+          'database' => { 'id' => 1, 'name' => 'DB1', 'backend' => 'postgres' },
+          'schema' => 'acme',
         'sql' => 'select * from acme.forecasts'
       }.with_indifferent_access,
       {
@@ -21,6 +22,7 @@ RSpec.describe Superset::Dashboard::Datasets::List do
         'sql' => 'select * from acme_new.forecasts'
       }.with_indifferent_access
     ]
+  }
   end
 
   before do
@@ -60,10 +62,12 @@ RSpec.describe Superset::Dashboard::Datasets::List do
 
   describe '#datasets_details' do
     it 'returns a list of datasets' do
-      expect(subject.datasets_details).to eq([
-        {"id"=>101, "datasource_name"=>"Acme Forecasts", "schema"=>"acme", "database"=>{"id"=>1, "name"=>"DB1", "backend"=>"postgres"}, "sql"=>"select * from acme.forecasts"},
-        {"id"=>102, "datasource_name"=>"video_game_sales", "schema"=>"public", "database"=>{"id"=>2, "name"=>"examples", "backend"=>"postgres"}, "sql"=>"select * from acme_new.forecasts"}
-      ])
+      expect(subject.datasets_details).to eq({
+        'datasets' => [
+          {"id"=>101, "datasource_name"=>"Acme Forecasts", "schema"=>"acme", "database"=>{"id"=>1, "name"=>"DB1", "backend"=>"postgres"}, "sql"=>"select * from acme.forecasts"},
+          {"id"=>102, "datasource_name"=>"video_game_sales", "schema"=>"public", "database"=>{"id"=>2, "name"=>"examples", "backend"=>"postgres"}, "sql"=>"select * from acme_new.forecasts"}
+        ]
+      })
     end
 
     context 'returns both chart and filter datasets when include_filter_datasets is true' do


### PR DESCRIPTION
1) Dashboard::Datasets::List.new now accepts a new parameter separate_shared_datasets which when true makes the instance method dataset_details to return the results this way
`{
'datasets' => [],
'shared_datasets' => []
}`
Here shared_datasets holds the datasets that are being shared across different dashboards filters.
Eg: `On the books month` dataset
This is useful when we do a bulk delete cascade for recreation of dashboards to ignore the deletion shared datasets which will cause all the dashboards using the dataset to break.

To set the dataset as shared dataset, we use the extra field in superset dataset settings.