### PR TITLE
Nep 20232 filter boards by exact tag

### DIFF
--- a/lib/superset/dashboard/list.rb
+++ b/lib/superset/dashboard/list.rb
@@ -5,12 +5,15 @@
 module Superset
   module Dashboard
     class List < Superset::Request
-      attr_reader :title_contains, :title_equals, :tags_equal, :ids_not_in, :include_filter_dataset_schemas
+      attr_reader :title_contains, :title_equals,
+                  :tags_contain, :tags_match,
+                  :ids_not_in, :include_filter_dataset_schemas
 
-      def initialize(page_num: 0, title_contains: '', title_equals: '', tags_equal: [], ids_not_in: [], include_filter_dataset_schemas: false)
+      def initialize(page_num: 0, title_contains: '', title_equals: '', tags_contain: [], tags_match: [], ids_not_in: [], include_filter_dataset_schemas: false)
         @title_contains = title_contains
         @title_equals = title_equals
-        @tags_equal = tags_equal
+        @tags_contain = tags_contain
+        @tags_match = tags_match
         @ids_not_in = ids_not_in
         @include_filter_dataset_schemas = include_filter_dataset_schemas
         super(page_num: page_num)
@@ -72,15 +75,16 @@ module Superset
         filter_set = []
         filter_set << "(col:dashboard_title,opr:ct,value:'#{title_contains}')" if title_contains.present?
         filter_set << "(col:dashboard_title,opr:eq,value:'#{title_equals}')" if title_equals.present?
-        filter_set << tag_filters if tags_equal.present?
+        filter_set << tags_contain_filters if tags_contain.present?
         filter_set << ids_not_in_filters if ids_not_in.present?
+
         unless filter_set.empty?
           "filters:!(" + filter_set.join(',') + "),"
         end
       end
 
-      def tag_filters
-        tags_equal.map {|tag| "(col:tags,opr:dashboard_tags,value:'#{tag}')"}.join(',')
+      def tags_contain_filters
+        tags_contain.map {|tag| "(col:tags,opr:dashboard_tags,value:'#{tag}')"}.join(',')
       end
 
       def ids_not_in_filters
@@ -94,8 +98,8 @@ module Superset
       def validate_constructor_args
         raise InvalidParameterError, "title_contains must be a String type" unless title_contains.is_a?(String)
         raise InvalidParameterError, "title_equals must be a String type" unless title_equals.is_a?(String)
-        raise InvalidParameterError, "tags_equal must be an Array type" unless tags_equal.is_a?(Array)
-        raise InvalidParameterError, "tags_equal array must contain string only values" unless tags_equal.all? { |item| item.is_a?(String) }
+        raise InvalidParameterError, "tags_contain must be an Array type" unless tags_contain.is_a?(Array)
+        raise InvalidParameterError, "tags_contain array must contain string only values" unless tags_contain.all? { |item| item.is_a?(String) }
         raise InvalidParameterError, "ids_not_in must be an Array type" unless ids_not_in.is_a?(Array)
       end
     end

--- a/lib/superset/tag/list.rb
+++ b/lib/superset/tag/list.rb
@@ -23,7 +23,7 @@ module Superset
         # TODO filtering across all list classes can be refactored to support multiple options in a more flexible way
         filter_set = []
         filter_set << "(col:name,opr:ct,value:'#{name_contains}')" if name_contains.present?
-        filter_set << "(col:name,opr:eq,value:#{name_equals})" if name_equals.present?  
+        filter_set << "(col:name,opr:eq,value:'#{name_equals}')" if name_equals.present?
         unless filter_set.empty?
           "filters:!(" + filter_set.join(',') + "),"
         end

--- a/spec/superset/dashboard/list_spec.rb
+++ b/spec/superset/dashboard/list_spec.rb
@@ -109,5 +109,22 @@ RSpec.describe Superset::Dashboard::List do
           "),page:3,page_size:100")
       end
     end
+
+    context 'with multiple tags_equal filters' do
+      subject { described_class.new(tags_equal: ['client:acme', 'embedded']) }
+
+      before do
+        allow(Superset::Tag::List).to receive(:new).with(name_equals: 'client:acme').and_return(double(rows: [['101']]))
+        allow(Superset::Tag::List).to receive(:new).with(name_equals: 'embedded').and_return(double(rows: [['202']]))
+      end
+
+      specify do
+        expect(subject.query_params).to eq(
+          "filters:!(" \
+          "(col:tags,opr:dashboard_tag_id,value:101)," \
+          "(col:tags,opr:dashboard_tag_id,value:202)" \
+          "),page:0,page_size:100")
+      end
+    end
   end
 end

--- a/spec/superset/dashboard/list_spec.rb
+++ b/spec/superset/dashboard/list_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Superset::Dashboard::List do
     end
 
     context 'with multiple filter set' do
-      subject { described_class.new(title_contains: 'birth', tags_equal: ['template']) }
+      subject { described_class.new(title_contains: 'birth', tags_contain: ['template']) }
 
       specify do
         expect(subject.query_params).to eq(
@@ -96,7 +96,7 @@ RSpec.describe Superset::Dashboard::List do
     end
 
     context 'with multiple filter set and multiple tags' do
-      subject { described_class.new(page_num: 3, title_contains: 'birth', title_equals: 'births in aust', tags_equal: ['template', 'client:acme', 'product:turbo-charged-feet']) }
+      subject { described_class.new(page_num: 3, title_contains: 'birth', title_equals: 'births in aust', tags_contain: ['template', 'client:acme', 'product:turbo-charged-feet']) }
 
       specify do
         expect(subject.query_params).to eq(

--- a/spec/superset/tag/list_spec.rb
+++ b/spec/superset/tag/list_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe Superset::Tag::List do
       )
     end
   end
+
+  describe '#query_params' do
+    context 'for pagination' do
+      context 'with defaults' do
+        specify do
+          expect(subject.query_params).to eq("page:0,page_size:100")
+        end
+      end
+
+      context 'with name_contains filters' do
+        subject { described_class.new(name_contains: 'acme') }
+
+        specify do
+          expect(subject.query_params).to eq("filters:!((col:name,opr:ct,value:'acme')),page:0,page_size:100")
+        end
+      end
+
+      context 'with name_equals filters' do
+        subject { described_class.new(name_equals: 'acme') }
+
+        specify do
+          expect(subject.query_params).to eq("filters:!((col:name,opr:eq,value:'acme')),page:0,page_size:100")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jobready.atlassian.net/browse/NEP-20232

- add ability to filter dashboard by exact tag


```ruby
Superset::Dashboard::List.new(tags_equal: ['client:acme']).list


Superset::Dashboard::List.new(tags_equal: ['client:acme_stage']).list

```