### PR TITLE
[NEP-20242] add database catalog endpoint call

### DIFF
--- a/lib/superset/database/get_catalogs.rb
+++ b/lib/superset/database/get_catalogs.rb
@@ -1,0 +1,38 @@
+module Superset
+  module Database
+    class GetCatalogs < Superset::Request
+
+      attr_reader :id, :include_system_catalogs
+
+      def initialize(id, include_system_catalogs: false)
+        @id = id
+        @include_system_catalogs = include_system_catalogs
+      end
+
+      def self.call(id)
+        self.new(id).catalogs
+      end
+ 
+      def catalogs
+        return result if include_system_catalogs
+
+        remove_system_catalogs
+      end
+
+      private
+
+      def route
+        "database/#{id}/catalogs/"
+      end
+
+      # exclude system catalog values for certain databases that support them
+      def remove_system_catalogs
+        result - postgres_system_catalogs
+      end
+
+      def postgres_system_catalogs
+        %w(postgres rdsadmin template1 template0)
+      end
+    end
+  end
+end

--- a/spec/superset/database/get_catalogs_spec.rb
+++ b/spec/superset/database/get_catalogs_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe Superset::Database::GetCatalogs do
+  subject { described_class.new(id, **opts) }
+  let(:id) { 111 }
+  let(:opts) { {} }
+  let(:full_catalog_list) do
+    [
+      "postgres",
+      "rdsadmin",
+      "template1",
+      "pool_1_clients"
+    ]
+  end
+
+  before do
+    allow(subject).to receive(:result).and_return(full_catalog_list)
+  end
+
+  describe '.call' do
+    specify do
+      expect_any_instance_of(described_class).to receive(:catalogs)
+      described_class.call(id)
+    end
+  end
+
+  describe '#catalogs' do
+    specify 'by default excludes system catalogs' do
+      expect(subject.catalogs).to eq ["pool_1_clients"]
+    end
+
+    context 'when include_system_catalogs is true' do
+      let(:opts) { { include_system_catalogs: true } }
+     
+      specify 'can optionally include system catalogs' do
+        expect(subject.catalogs).to eq full_catalog_list
+      end
+    end
+  end
+end


### PR DESCRIPTION

Relates to a bug in SS V5 related to default catalogs
https://github.com/apache/superset/pull/35004

This pr adds ability to retrieve database catalogs

```ruby

Superset::Database::GetCatalogs.new(1, include_system_catalogs: true).catalogs
=> ["rdsadmin", "acme01_dlm_sensitive", "postgres"]

Superset::Database::GetCatalogs.new(1).catalogs
=> ["acme01_dlm_sensitive"]

```
