### PR TITLE
allow for empty filter datasets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    superset (0.3.4)
+    superset (0.3.5)
       enumerate_it (>= 1.7)
       faraday (~> 1.0)
       faraday-multipart (~> 1.0)

--- a/lib/superset/dashboard/datasets/list.rb
+++ b/lib/superset/dashboard/datasets/list.rb
@@ -73,7 +73,7 @@ module Superset
 
           chart_dataset_ids = chart_datasets.map{|d| d['id'] }
           filter_dataset_ids_not_used_in_charts = filter_dataset_ids - chart_dataset_ids
-          retrieve_filter_datasets(filter_dataset_ids_not_used_in_charts) unless filter_dataset_ids_not_used_in_charts.empty?
+          filter_dataset_ids_not_used_in_charts.empty? ? [] : retrieve_filter_datasets(filter_dataset_ids_not_used_in_charts)
         end
 
         def filter_dataset_ids

--- a/lib/superset/dashboard/datasets/list.rb
+++ b/lib/superset/dashboard/datasets/list.rb
@@ -9,7 +9,7 @@ module Superset
       class List < Superset::Request
         attr_reader :dashboard_id, :include_filter_datasets, :include_catalog_lookup # id - dashboard id
 
-        def initialize(dashboard_id:, include_filter_datasets: false, include_catalog_lookup: false)
+        def initialize(dashboard_id:, include_filter_datasets: true, include_catalog_lookup: true)
           @dashboard_id = dashboard_id
           @include_filter_datasets = include_filter_datasets
           @include_catalog_lookup = include_catalog_lookup
@@ -22,7 +22,7 @@ module Superset
 
         def datasets_details
           @datasets_details ||= begin
-            datasets_list = chart_datasets + additional_filter_datasets
+            datasets_list = chart_datasets + Array(additional_filter_datasets)
             datasets_list = include_catalog_details(datasets_list) if include_catalog_lookup
             datasets_list.compact
           end
@@ -42,15 +42,9 @@ module Superset
 
         def rows
           datasets_details.map do |d|
-            [
-              d[:id],
-              d[:datasource_name],
-              d[:database][:id],
-              d[:database][:name],
-              d[:database][:backend],
-              d[:schema],
-              d[:filter_only]
-            ]
+            row = [d[:id], d[:datasource_name], d[:database][:backend], d[:database][:id], d[:database][:name]]
+            row << d[:catalog] if include_catalog_lookup
+            row + [d[:schema], d[:filter_only]]
           end
         end
 
@@ -69,11 +63,11 @@ module Superset
 
         # list of any additional filter dataset details on the dashboard that are not used in charts
         def additional_filter_datasets
-          return [] unless include_filter_datasets
+          return unless include_filter_datasets
 
           chart_dataset_ids = chart_datasets.map{|d| d['id'] }
           filter_dataset_ids_not_used_in_charts = filter_dataset_ids - chart_dataset_ids
-          filter_dataset_ids_not_used_in_charts.empty? ? [] : retrieve_filter_datasets(filter_dataset_ids_not_used_in_charts)
+          retrieve_filter_datasets(filter_dataset_ids_not_used_in_charts)
         end
 
         def filter_dataset_ids
@@ -100,7 +94,9 @@ module Superset
         end
 
         def list_attributes
-          ['id', 'datasource_name', 'database_id', 'database_name', 'database_backend', 'schema', 'filter_only'].map(&:to_sym)
+          base = %w[id datasource_name database_backend database_id database_name]
+          base << 'catalog' if include_catalog_lookup
+          (base + %w[schema filter_only]).map(&:to_sym)
         end
 
         # when displaying a list of datasets, show dashboard title as well

--- a/lib/superset/version.rb
+++ b/lib/superset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Superset
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/superset/dashboard/datasets/list_spec.rb
+++ b/spec/superset/dashboard/datasets/list_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe Superset::Dashboard::Datasets::List do
   describe '#table' do
     before do
       allow(subject).to receive(:datasets_details).and_return(([
-        {"id"=>101, "datasource_name"=>"Acme Forecasts", "schema"=>"acme", "database"=>{"id"=>1, "name"=>"DB1", "backend"=>"postgres"}, "sql"=>"select * from acme.forecasts"},
-        {"id"=>102, "datasource_name"=>"video_game_sales", "schema"=>"public", "database"=>{"id"=>2, "name"=>"examples", "backend"=>"postgres"}, "sql"=>"select * from acme_new.forecasts"}
+        {"id"=>101, "datasource_name"=>"Acme Forecasts", "schema"=>"acme", "database"=>{"id"=>1, "name"=>"DB1", "backend"=>"postgres"}, "sql"=>"select * from acme.forecasts", "catalog"=>"acme_client_catalog"},
+        {"id"=>102, "datasource_name"=>"video_game_sales", "schema"=>"public", "database"=>{"id"=>2, "name"=>"examples", "backend"=>"postgres"}, "sql"=>"select * from acme_new.forecasts", "catalog"=>"examples_client_catalog"}
       ]+ filter_dataset_json).map(&:with_indifferent_access))
     end
     let(:filter_dataset_json) { [] }
@@ -135,12 +135,12 @@ RSpec.describe Superset::Dashboard::Datasets::List do
       expect(subject.table.to_s).to eq(
         "+---------------------------------------------------------------------------------------------+\n" \
         "|                                      1: Test Dashboard                                      |\n" \
-        "+-----+------------------+----------+---------------+------------------+--------+-------------+\n" \
-        "| Id  | Datasource name  | Database | Database name | Database backend | Schema | Filter only |\n" \
-        "+-----+------------------+----------+---------------+------------------+--------+-------------+\n" \
-        "| 101 | Acme Forecasts   | 1        | DB1           | postgres         | acme   |             |\n" \
-        "| 102 | video_game_sales | 2        | examples      | postgres         | public |             |\n" \
-        "+-----+------------------+----------+---------------+------------------+--------+-------------+"
+        "+-----+------------------+------------------+----------+---------------+--------+-------------+\n" \
+        "| Id  | Datasource name  | Database backend | Database | Database name | Schema | Filter only |\n" \
+        "+-----+------------------+------------------+----------+---------------+--------+-------------+\n" \
+        "| 101 | Acme Forecasts   | postgres         | 1        | DB1           | acme   |             |\n" \
+        "| 102 | video_game_sales | postgres         | 2        | examples      | public |             |\n" \
+        "+-----+------------------+------------------+----------+---------------+--------+-------------+"
       )
     end
 
@@ -178,14 +178,31 @@ RSpec.describe Superset::Dashboard::Datasets::List do
         expect(subject.table.to_s).to eq(
           "+---------------------------------------------------------------------------------------------+\n" \
           "|                                      1: Test Dashboard                                      |\n" \
-          "+-----+------------------+----------+---------------+------------------+--------+-------------+\n" \
-          "| Id  | Datasource name  | Database | Database name | Database backend | Schema | Filter only |\n" \
-          "+-----+------------------+----------+---------------+------------------+--------+-------------+\n" \
-          "| 101 | Acme Forecasts   | 1        | DB1           | postgres         | acme   |             |\n" \
-          "| 102 | video_game_sales | 2        | examples      | postgres         | public |             |\n" \
-          "| 103 | Filter 1         | 1        | DB1           | postgres         | acme   | true        |\n" \
-          "| 104 | Filter 2         | 2        | examples      | postgres         | public | true        |\n" \
-          "+-----+------------------+----------+---------------+------------------+--------+-------------+"
+          "+-----+------------------+------------------+----------+---------------+--------+-------------+\n" \
+          "| Id  | Datasource name  | Database backend | Database | Database name | Schema | Filter only |\n" \
+          "+-----+------------------+------------------+----------+---------------+--------+-------------+\n" \
+          "| 101 | Acme Forecasts   | postgres         | 1        | DB1           | acme   |             |\n" \
+          "| 102 | video_game_sales | postgres         | 2        | examples      | public |             |\n" \
+          "| 103 | Filter 1         | postgres         | 1        | DB1           | acme   | true        |\n" \
+          "| 104 | Filter 2         | postgres         | 2        | examples      | public | true        |\n" \
+          "+-----+------------------+------------------+----------+---------------+--------+-------------+"
+        )
+      end
+    end
+
+    context 'prints a table with the dashboard title with chart and filter datasets and catalogs' do
+      let(:include_catalog_lookup) { true }
+      let(:filter_dataset_json) { [] }
+      specify do
+        expect(subject.table.to_s).to eq(
+          "+-----------------------------------------------------------------------------------------------------------------------+\n" \
+          "|                                                   1: Test Dashboard                                                   |\n" \
+          "+-----+------------------+------------------+----------+---------------+-------------------------+--------+-------------+\n" \
+          "| Id  | Datasource name  | Database backend | Database | Database name | Catalog                 | Schema | Filter only |\n" \
+          "+-----+------------------+------------------+----------+---------------+-------------------------+--------+-------------+\n" \
+          "| 101 | Acme Forecasts   | postgres         | 1        | DB1           | acme_client_catalog     | acme   |             |\n" \
+          "| 102 | video_game_sales | postgres         | 2        | examples      | examples_client_catalog | public |             |\n" \
+          "+-----+------------------+------------------+----------+---------------+-------------------------+--------+-------------+"
         )
       end
     end


### PR DESCRIPTION
A recent change introduced a bug around including db catalog names in the datasets list
introduced a bug relating to when no datasets are only used by filters.
https://github.com/rdytech/superset-client/pull/69

- fix bug for when no filter only datasets are used
- adjust constructor defaults 
- optionally show catalog on console list method

```
Superset::Dashboard::Datasets::List.new(dashboard_id: 15).list



```