### PR TITLE
Upgrade to rubyzip 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-## Change Log
+## Changelog
+
+## 0.3.6 - 2026-02-27
+
+* update to rubyzip 3.2.2 #73
+
+## 0.3.5 - 2026-02-26
+
+* allow for empty filter datasets #72
+
+## 0.3.4 - 2026-02-21
+
+* cascade ownership should also update datasets for filter only in #68
+* add owner filter #62
+* list dataset catalog db names #69
+* bump version to 0.3.4 #70
+* Adjust asset order for board cascade deletion #71
 
 ## 0.3.3 - 2025-12-11
 * Add databases method to Superset::Dashboard::Datasets::List

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-## 0.3.6 - 2026-02-27
+## (WIP) 0.3.6 -
 
 * update to rubyzip 3.2.2 #73
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    superset (0.3.6)
+    superset (0.3.5)
       enumerate_it (>= 1.7)
       faraday (~> 1.0)
       faraday-multipart (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    superset (0.3.5)
+    superset (0.3.6)
       enumerate_it (>= 1.7)
       faraday (~> 1.0)
       faraday-multipart (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       faraday-multipart (~> 1.0)
       json (>= 2.0)
       require_all (>= 3.0)
-      rubyzip (>= 1.3)
+      rubyzip (>= 3.0)
       terminal-table (~> 4.0)
 
 GEM
@@ -136,7 +136,7 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (1.3.0)
+    rubyzip (3.2.2)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     tzinfo (2.0.6)

--- a/lib/superset/dashboard/export.rb
+++ b/lib/superset/dashboard/export.rb
@@ -3,8 +3,12 @@
 # Will then unzip and copy the files into the destination_path with the dashboard_id as a subfolder
 #
 # Usage
-# Superset::Dashboard::Export.new(dashboard_id: 15, destination_path: '/tmp/superset_dashboard_backups/').perform
-#
+=begin
+  Superset::Dashboard::Export.new(
+    dashboard_id: 15,
+    destination_path: '/superset_dashboard_backups/'
+  ).perform
+=end
 
 require 'superset/file_utilities'
 
@@ -13,7 +17,7 @@ module Superset
     class Export < Request
       include FileUtilities
 
-      TMP_SUPERSET_DASHBOARD_PATH = '/tmp/superset_dashboard_exports'
+      TMP_SUPERSET_DASHBOARD_PATH = '/tmp/superset_dashboard_exports'.freeze
 
       attr_reader :dashboard_id, :destination_path
 
@@ -62,7 +66,6 @@ module Superset
 
       def unzip_files
         logger.info("Unzipping file: #{zip_file_name}")
-        binding.pry
         @extracted_files = unzip_file(zip_file_name, tmp_uniq_dashboard_path)
       end
 
@@ -125,21 +128,6 @@ module Superset
 
       def datestamp
         @datestamp ||= Time.now.strftime('%Y%m%d')
-      end
-
-      def unzip_file(zip_path, destination)
-        extracted_files = []
-        Zip::File.open(zip_path) do |zip_file|
-          zip_file.each do |entry|
-            entry_path = File.join(destination, entry.name)
-            FileUtils.mkdir_p(File.dirname(entry_path))
-            zip_file.extract(entry, entry_path, destination_directory: '/') unless File.exist?(entry_path)
-            extracted_files << entry_path
-          end
-        end
-        extracted_files
-      rescue => e
-        raise
       end
     end
 

--- a/lib/superset/dashboard/export.rb
+++ b/lib/superset/dashboard/export.rb
@@ -31,7 +31,7 @@ module Superset
         create_tmp_dir
         save_exported_zip_file
         unzip_files
-        #clean_destination_directory
+        clean_destination_directory
         copy_export_files_to_destination_path if destination_path
 
         Dir.glob("#{destination_path_with_dash_id}/**/*").select { |f| File.file?(f) }

--- a/lib/superset/dashboard/export.rb
+++ b/lib/superset/dashboard/export.rb
@@ -27,7 +27,7 @@ module Superset
         create_tmp_dir
         save_exported_zip_file
         unzip_files
-        clean_destination_directory
+        #clean_destination_directory
         copy_export_files_to_destination_path if destination_path
 
         Dir.glob("#{destination_path_with_dash_id}/**/*").select { |f| File.file?(f) }
@@ -62,6 +62,7 @@ module Superset
 
       def unzip_files
         logger.info("Unzipping file: #{zip_file_name}")
+        binding.pry
         @extracted_files = unzip_file(zip_file_name, tmp_uniq_dashboard_path)
       end
 
@@ -132,7 +133,7 @@ module Superset
           zip_file.each do |entry|
             entry_path = File.join(destination, entry.name)
             FileUtils.mkdir_p(File.dirname(entry_path))
-            zip_file.extract(entry, entry_path) unless File.exist?(entry_path)
+            zip_file.extract(entry, entry_path, destination_directory: '/') unless File.exist?(entry_path)
             extracted_files << entry_path
           end
         end

--- a/lib/superset/dashboard/import.rb
+++ b/lib/superset/dashboard/import.rb
@@ -78,7 +78,7 @@ module Superset
       def source_zip_file
         return source if zip?
 
-        Zip::File.open(new_zip_file, Zip::File::CREATE) do |zipfile|
+        Zip::File.open(new_zip_file, create: true) do |zipfile|
           Dir[File.join(source, "**", "**")].each do |file|
             next unless File.file?(file)
 

--- a/lib/superset/file_utilities.rb
+++ b/lib/superset/file_utilities.rb
@@ -12,7 +12,7 @@ module Superset
           entries << entry_path
           FileUtils.mkdir_p(File.dirname(entry_path))
 
-          zip.extract(entry, entry_path, destination_directory: '/') unless File.exist?(entry_path)
+          zip.extract(entry, entry_path, destination_directory: '/') { true }
         rescue => e
           raise "Error extracting file #{entry.name}: #{e.message}"
         end

--- a/lib/superset/file_utilities.rb
+++ b/lib/superset/file_utilities.rb
@@ -12,8 +12,6 @@ module Superset
           entries << entry_path
           FileUtils.mkdir_p(File.dirname(entry_path))
 
-          # RubyZip 3.x: destination_directory must allow our absolute entry_path.
-          # Default '.' makes extract_path fail start_with?(dest_dir) and skip extraction.
           zip.extract(entry, entry_path, destination_directory: '/') unless File.exist?(entry_path)
         rescue => e
           raise "Error extracting file #{entry.name}: #{e.message}"

--- a/lib/superset/file_utilities.rb
+++ b/lib/superset/file_utilities.rb
@@ -6,11 +6,17 @@ module Superset
       entries = []
       Zip::File.open(zip_file) do |zip|
         zip.each do |entry|
+          next if entry.name.empty?
+
           entry_path = File.join(destination, entry.name)
           entries << entry_path
           FileUtils.mkdir_p(File.dirname(entry_path))
 
-          zip.extract(entry, entry_path) unless File.exist?(entry_path)
+          # RubyZip 3.x: destination_directory must allow our absolute entry_path.
+          # Default '.' makes extract_path fail start_with?(dest_dir) and skip extraction.
+          zip.extract(entry, entry_path, destination_directory: '/') unless File.exist?(entry_path)
+        rescue => e
+          raise "Error extracting file #{entry.name}: #{e.message}"
         end
       end
 

--- a/lib/superset/file_utilities.rb
+++ b/lib/superset/file_utilities.rb
@@ -12,7 +12,7 @@ module Superset
           entries << entry_path
           FileUtils.mkdir_p(File.dirname(entry_path))
 
-          zip.extract(entry, entry_path, destination_directory: '/') { true }
+          zip.extract(entry, entry.name, destination_directory: destination) { true }
         rescue => e
           raise "Error extracting file #{entry.name}: #{e.message}"
         end

--- a/lib/superset/services/import_dashboard_across_environment.rb
+++ b/lib/superset/services/import_dashboard_across_environment.rb
@@ -87,7 +87,7 @@ module Superset
       end
 
       def create_new_dashboard_zip
-        Zip::File.open(new_zip_file, Zip::File::CREATE) do |zipfile|
+        Zip::File.open(new_zip_file, create: true) do |zipfile|
           Dir[File.join(dashboard_export_root_path, '**', '**')].each do |file|
             zipfile.add(file.sub(dashboard_export_root_path + '/', File.basename(dashboard_export_root_path) + '/' ), file) if File.file?(file)
           end

--- a/lib/superset/version.rb
+++ b/lib/superset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Superset
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end

--- a/lib/superset/version.rb
+++ b/lib/superset/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Superset
-  VERSION = "0.3.6"
+  VERSION = "0.3.5"
 end

--- a/spec/superset/dashboard/import_spec.rb
+++ b/spec/superset/dashboard/import_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Superset::Dashboard::Import do
 
         # Mock Zip::File.open to prevent actual zip creation
         zip_file_double = double("Zip::File")
-        allow(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE).and_yield(zip_file_double)
+        allow(Zip::File).to receive(:open).with(new_zip_file, create: true).and_yield(zip_file_double)
         allow(zip_file_double).to receive(:add)
 
         # Mock Dir[] to return a list of files
@@ -190,13 +190,13 @@ RSpec.describe Superset::Dashboard::Import do
       end
 
       it "creates a zip file and returns its path" do
-        expect(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE)
+        expect(Zip::File).to receive(:open).with(new_zip_file, create: true)
         expect(subject.send(:source_zip_file)).to eq(new_zip_file)
       end
 
       it "adds directory content to the zip file" do
         zip_file_double = double("Zip::File")
-        expect(Zip::File).to receive(:open).with(new_zip_file, Zip::File::CREATE).and_yield(zip_file_double)
+        expect(Zip::File).to receive(:open).with(new_zip_file, create: true).and_yield(zip_file_double)
 
         expect(zip_file_double).to receive(:add).with(
           "dashboard_import_#{subject.send(:timestamp)}/file1.yaml", "#{source}/file1.yaml"

--- a/spec/superset/dashboard/import_spec.rb
+++ b/spec/superset/dashboard/import_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Superset::Dashboard::Import do
           zip_file.each do |f|
             fpath = File.join(tmp_dir, f.name)
             FileUtils.mkdir_p(File.dirname(fpath))
-            zip_file.extract(f, fpath) unless File.exist?(fpath)
+            zip_file.extract(f, f.name, destination_directory: tmp_dir) { true }
           end
         end
         "#{tmp_dir}/dashboard_export_20240321T214117"

--- a/spec/superset/file_utilties_spec.rb
+++ b/spec/superset/file_utilties_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'superset/file_utilities'
+require 'tmpdir'
+
+RSpec.describe Superset::FileUtilities do
+  # Test via a class that includes the module
+  let(:dummy_class) do
+    Class.new do
+      include Superset::FileUtilities
+    end
+  end
+  let(:subject) { dummy_class.new }
+
+  describe '#unzip_file' do
+    let(:destination) { Dir.mktmpdir('unzip_file_spec') }
+
+    after do
+      FileUtils.rm_rf(destination) if Dir.exist?(destination)
+    end
+
+    context 'with a valid zip file' do
+      let(:zip_path) { File.join(destination, 'test.zip') }
+
+      before do
+        Zip::File.open(zip_path, create: true) do |zip|
+          zip.get_output_stream('foo.txt') { |f| f.write('hello') }
+          zip.get_output_stream('bar/nested.txt') { |f| f.write('nested') }
+        end
+      end
+
+      it 'extracts all entries to the destination and returns their paths' do
+        result = subject.unzip_file(zip_path, destination)
+
+        expect(result).to match_array([
+          File.join(destination, 'foo.txt'),
+          File.join(destination, 'bar/nested.txt')
+        ])
+      end
+
+      it 'creates the expected files on disk' do
+        subject.unzip_file(zip_path, destination)
+
+        expect(File.read(File.join(destination, 'foo.txt'))).to eq('hello')
+        expect(File.read(File.join(destination, 'bar/nested.txt'))).to eq('nested')
+      end
+
+      it 'overwrites existing files with zip contents' do
+        existing = File.join(destination, 'foo.txt')
+        FileUtils.mkdir_p(File.dirname(existing))
+        File.write(existing, 'existing')
+
+        subject.unzip_file(zip_path, destination)
+
+        expect(File.read(existing)).to eq('hello')
+      end
+    end
+
+    context 'with destination as absolute path (RubyZip 3.x compatibility)' do
+      it 'extracts successfully when destination is absolute' do
+        zip_path = File.join(destination, 'abs.zip')
+        Zip::File.open(zip_path, create: true) do |zip|
+          zip.get_output_stream('single.txt') { |f| f.write('x') }
+        end
+
+        result = subject.unzip_file(zip_path, destination)
+
+        expect(result).to include(File.join(destination, 'single.txt'))
+        expect(File.read(File.join(destination, 'single.txt'))).to eq('x')
+      end
+    end
+
+    context 'with empty entry names' do
+      it 'skips entries with empty names and does not raise' do
+        zip_path = File.join(destination, 'empty_entries.zip')
+        # Create zip with one valid entry; empty-name entries are rare but we test the skip
+        Zip::File.open(zip_path, create: true) do |zip|
+          zip.get_output_stream('valid.txt') { |f| f.write('ok') }
+        end
+
+        result = subject.unzip_file(zip_path, destination)
+
+        expect(result).to eq([File.join(destination, 'valid.txt')])
+        expect(File.read(File.join(destination, 'valid.txt'))).to eq('ok')
+      end
+    end
+
+    context 'when zip file does not exist' do
+      it 'raises when opening the zip fails' do
+        expect {
+          subject.unzip_file(File.join(destination, 'nonexistent.zip'), destination)
+        }.to raise_error(Zip::Error, /not found/)
+      end
+    end
+  end
+end

--- a/spec/superset/file_utilties_spec.rb
+++ b/spec/superset/file_utilties_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe Superset::FileUtilities do
         expect(result).to eq([File.join(destination, 'valid.txt')])
         expect(File.read(File.join(destination, 'valid.txt'))).to eq('ok')
       end
+
+      it 'skips entries whose name is empty (zip slip / malformed zip guard)' do
+        zip_path = File.join(destination, 'with_empty_name.zip')
+        Zip::File.open(zip_path, create: true) do |zip|
+          zip.get_output_stream('valid.txt') { |f| f.write('content') }
+        end
+
+        # Stub to simulate a zip that yields an entry with empty name before the real entry
+        empty_name_entry = double('Zip::Entry', name: '')
+        allow(Zip::File).to receive(:open).and_wrap_original do |method, path, *args, &block|
+          method.call(path, *args) do |z|
+            real_entries = z.entries
+            allow(z).to receive(:each) do |&iter_block|
+              iter_block.call(empty_name_entry)
+              real_entries.each(&iter_block)
+            end
+            block.call(z)
+          end
+        end
+
+        result = subject.unzip_file(zip_path, destination)
+
+        expect(result).to eq([File.join(destination, 'valid.txt')])
+        expect(File.read(File.join(destination, 'valid.txt'))).to eq('content')
+      end
     end
 
     context 'when zip file does not exist' do

--- a/superset.gemspec
+++ b/superset.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json", ">= 2.0"
   spec.add_dependency "terminal-table", "~> 4.0"
   spec.add_dependency "require_all", ">= 3.0"
-  spec.add_dependency "rubyzip", ">= 1.3"
+  spec.add_dependency "rubyzip", ">= 3.0"
   spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "faraday-multipart", "~> 1.0"
   spec.add_dependency "enumerate_it", ">= 1.7"


### PR DESCRIPTION
# PR Overview

This pull request upgrades the rubyzip dependency from version 1.3 to 3.2.2, addressing breaking API changes introduced in rubyzip 3.0. The upgrade is primarily motivated by security improvements and API modernization in the newer version of rubyzip.

Changes:

* Updated rubyzip dependency constraint from ">= 1.3" to ">= 3.0" in gemspec
* Replaced Zip::File::CREATE constant with create: true keyword argument in all zip creation operations
* Added security features to unzip_file method: empty name check and destination_directory parameter
* Removed duplicate unzip_file method from Export class, consolidating it in FileUtilities module
* Added .freeze to TMP_SUPERSET_DASHBOARD_PATH constant
