### PR TITLE
Add dry run to board del cascade

### DIFF
--- a/lib/superset/dashboard/bulk_delete_cascade.rb
+++ b/lib/superset/dashboard/bulk_delete_cascade.rb
@@ -21,9 +21,16 @@ module Superset
         raise InvalidParameterError, "dashboard_ids array must contain Integer only values" unless dashboard_ids.all? { |item| item.is_a?(Integer) }
 
         dashboard_ids.sort.each do |dashboard_id|
-          logger.info("Dashboard Id: #{dashboard_id.to_s} Attempting CASCADE delete of dashboard, charts, datasets")
-          delete_charts(dashboard_id)
-          delete_datasets(dashboard_id)
+          chart_ids = retrieve_chart_ids(dashboard_id)
+          dataset_ids = retrieve_dataset_ids(dashboard_id)
+
+          log_msg("------------------------- DRY RUN ONLY ---------------------------") if dry_run
+          log_msg("Dashboard Id: #{dashboard_id.to_s} Attempting CASCADE delete of dashboard, charts, datasets")
+          log_msg("  Charts: #{chart_ids.sort.join(', ')}")
+          log_msg("  Datasets: #{dataset_ids.sort.join(', ')}")
+
+          delete_charts(chart_ids)
+          delete_datasets(dataset_ids)
           delete_dashboard(dashboard_id)
         end
         true
@@ -31,30 +38,29 @@ module Superset
 
       private
 
-      def delete_datasets(dashboard_id)
-        datasets_to_delete = Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).datasets_details.map{|d| d[:id] }
-        if dry_run
-          logger.info("  NOTICE: Dry run only. Would delete datasets: #{datasets_to_delete.join(', ')}")
-        else
-          Superset::Dataset::BulkDelete.new(dataset_ids: datasets_to_delete).perform if datasets_to_delete.any?
-        end
+      def delete_datasets(dataset_ids)
+        Superset::Dataset::BulkDelete.new(dataset_ids: dataset_ids).perform if dataset_ids.any? && !dry_run
       end
 
-      def delete_charts(dashboard_id)
-        charts_to_delete = Superset::Dashboard::Charts::List.new(dashboard_id).chart_ids
-        if dry_run
-          logger.info("  NOTICE: Dry run only. Would delete charts: #{charts_to_delete.join(', ')}")
-        else
-          Superset::Chart::BulkDelete.new(chart_ids: charts_to_delete).perform if charts_to_delete.any?
-        end
+      def delete_charts(chart_ids)
+        Superset::Chart::BulkDelete.new(chart_ids: chart_ids).perform if chart_ids.any? && !dry_run
       end
 
       def delete_dashboard(dashboard_id)
-        if dry_run
-          logger.info("  NOTICE: Dry run only. Would delete dashboard: #{dashboard_id}")
-        else
-          Superset::Dashboard::Delete.new(dashboard_id: dashboard_id, confirm_zero_charts: true).perform
-        end
+        Superset::Dashboard::Delete.new(dashboard_id: dashboard_id, confirm_zero_charts: true).perform if !dry_run
+      end
+
+      def retrieve_chart_ids(dashboard_id)
+        Superset::Dashboard::Charts::List.new(dashboard_id).chart_ids
+      end
+
+      def retrieve_dataset_ids(dashboard_id)
+        Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).ids
+      end
+
+      def log_msg(message)
+        puts message
+        logger.info(message)
       end
 
       def logger

--- a/lib/superset/dashboard/bulk_delete_cascade.rb
+++ b/lib/superset/dashboard/bulk_delete_cascade.rb
@@ -9,10 +9,11 @@ module Superset
     class BulkDeleteCascade
       class InvalidParameterError < StandardError; end
 
-      attr_reader :dashboard_ids
+      attr_reader :dashboard_ids, :dry_run
 
-      def initialize(dashboard_ids: [])
+      def initialize(dashboard_ids: [], dry_run: true)
         @dashboard_ids = dashboard_ids
+        @dry_run = dry_run
       end
 
       def perform
@@ -32,16 +33,28 @@ module Superset
 
       def delete_datasets(dashboard_id)
         datasets_to_delete = Superset::Dashboard::Datasets::List.new(dashboard_id: dashboard_id).datasets_details.map{|d| d[:id] }
-        Superset::Dataset::BulkDelete.new(dataset_ids: datasets_to_delete).perform if datasets_to_delete.any?
+        if dry_run
+          logger.info("  NOTICE: Dry run only. Would delete datasets: #{datasets_to_delete.join(', ')}")
+        else
+          Superset::Dataset::BulkDelete.new(dataset_ids: datasets_to_delete).perform if datasets_to_delete.any?
+        end
       end
 
       def delete_charts(dashboard_id)
         charts_to_delete = Superset::Dashboard::Charts::List.new(dashboard_id).chart_ids
-        Superset::Chart::BulkDelete.new(chart_ids: charts_to_delete).perform if charts_to_delete.any?
+        if dry_run
+          logger.info("  NOTICE: Dry run only. Would delete charts: #{charts_to_delete.join(', ')}")
+        else
+          Superset::Chart::BulkDelete.new(chart_ids: charts_to_delete).perform if charts_to_delete.any?
+        end
       end
 
       def delete_dashboard(dashboard_id)
-        Superset::Dashboard::Delete.new(dashboard_id: dashboard_id, confirm_zero_charts: true).perform
+        if dry_run
+          logger.info("  NOTICE: Dry run only. Would delete dashboard: #{dashboard_id}")
+        else
+          Superset::Dashboard::Delete.new(dashboard_id: dashboard_id, confirm_zero_charts: true).perform
+        end
       end
 
       def logger

--- a/lib/superset/dataset/bulk_delete.rb
+++ b/lib/superset/dataset/bulk_delete.rb
@@ -16,10 +16,10 @@ module Superset
       end
 
       def perform
-        raise InvalidParameterError, "dataset_ids array of integers expected" unless dataset_ids.is_a?(Array)
+        raise InvalidParameterError, "dataset_ids array of integers expected" unless dataset_ids.is_a?(Array) && dataset_ids.any?
         raise InvalidParameterError, "dataset_ids array must contain Integer only values" unless dataset_ids.all? { |item| item.is_a?(Integer) }
 
-        logger.info("Deleting datasets with id: #{dataset_ids.join(', ')}")
+        logger.info("Deleting datasets with id: #{dataset_ids&.sort&.join(',')}")
         response
       end
 
@@ -30,7 +30,8 @@ module Superset
       private
 
       def params
-        { q: "!(#{dataset_ids.join(',')})" }
+        dataset_ids_str = dataset_ids&.sort&.join(',')
+        { q: "!(#{dataset_ids_str})" }
       end
 
       def route

--- a/spec/superset/dashboard/bulk_delete_cascade_spec.rb
+++ b/spec/superset/dashboard/bulk_delete_cascade_spec.rb
@@ -1,8 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe Superset::Dashboard::BulkDeleteCascade do
-  subject { described_class.new(dashboard_ids: dashboard_ids) }
+  subject { described_class.new(dashboard_ids: dashboard_ids, dry_run: dry_run) }
   let(:dashboard_ids) { nil }
+  let(:dry_run) { true }
+
+  describe '#dry_run' do
+    it 'defaults to true when not passed' do
+      instance = described_class.new(dashboard_ids: [1])
+      expect(instance.dry_run).to eq(true)
+    end
+  end
 
   describe '.perform' do
     context 'when dashboard_ids is not present' do
@@ -21,19 +29,46 @@ RSpec.describe Superset::Dashboard::BulkDeleteCascade do
 
     context 'when dashboard_ids are valid' do
       let(:dashboard_ids) { [1] }
+      let(:datasets_list) { double('Datasets::List', ids: [11, 12]) }
+      let(:charts_list) { double('Charts::List', chart_ids: [21, 22]) }
 
       before do
-        allow(Superset::Dashboard::Datasets::List).to receive(:new).with(dashboard_id: 1).and_return(double(datasets_details: [{ id: 11 }, { id: 12 }]))
-        allow(Superset::Dataset::BulkDelete).to receive(:new).with(dataset_ids: [11,12]).and_return(double(perform: true))
-
-        allow(Superset::Dashboard::Charts::List).to receive(:new).with(1).and_return(double(chart_ids: [21, 22]))
-        allow(Superset::Chart::BulkDelete).to receive(:new).with(chart_ids: [21, 22]).and_return(double(perform: true))
-
-        allow(Superset::Dashboard::Delete).to receive(:new).with(dashboard_id: 1, confirm_zero_charts: true).and_return(double(perform: true))
+        allow(Superset::Dashboard::Datasets::List).to receive(:new).with(dashboard_id: 1).and_return(datasets_list)
+        allow(Superset::Dashboard::Charts::List).to receive(:new).with(1).and_return(charts_list)
       end
 
-      it 'bulk deletes related charts, datasets and the dashboard' do
-        expect(subject.perform).to eq(true)
+      context 'when dry_run is true (default)' do
+        let(:dry_run) { true }
+
+        it 'returns true without calling delete services' do
+          expect(Superset::Dataset::BulkDelete).not_to receive(:new)
+          expect(Superset::Chart::BulkDelete).not_to receive(:new)
+          expect(Superset::Dashboard::Delete).not_to receive(:new)
+
+          expect(subject.perform).to eq(true)
+        end
+      end
+
+      context 'when dry_run is false' do
+        let(:dry_run) { false }
+
+        before do
+          allow(Superset::Dataset::BulkDelete).to receive(:new).with(dataset_ids: [11, 12]).and_return(double(perform: true))
+          allow(Superset::Chart::BulkDelete).to receive(:new).with(chart_ids: [21, 22]).and_return(double(perform: true))
+          allow(Superset::Dashboard::Delete).to receive(:new).with(dashboard_id: 1, confirm_zero_charts: true).and_return(double(perform: true))
+        end
+
+        it 'bulk deletes related charts, datasets and the dashboard' do
+          expect(subject.perform).to eq(true)
+        end
+
+        it 'calls Dataset::BulkDelete, Chart::BulkDelete and Dashboard::Delete' do
+          subject.perform
+
+          expect(Superset::Dataset::BulkDelete).to have_received(:new).with(dataset_ids: [11, 12])
+          expect(Superset::Chart::BulkDelete).to have_received(:new).with(chart_ids: [21, 22])
+          expect(Superset::Dashboard::Delete).to have_received(:new).with(dashboard_id: 1, confirm_zero_charts: true)
+        end
       end
     end
   end


### PR DESCRIPTION

- adds dry run to Dashboard::BulkDeleteCascade
- also fixes a bug in Dataset::BulkDelete .. where not all array items are converted to the params string
no clear bug found, but it appears to fix the issue.


```ruby
Superset::Dashboard::BulkDeleteCascade.new(dashboard_ids: [1204, 1205], dry_run: true).perform
------------------------- DRY RUN ONLY ---------------------------
Dashboard Id: 1204 Attempting CASCADE delete of dashboard, charts, datasets
  Charts: 65067, 65068, 65069, 65070, 65071, 65072, 65073, 65074, 65075, 65076, 65077, 65078, 65079, 65080, 65081, 65082, 65083, 65084, 65085, 65086, 65087, 65088, 65089, 65090, 65091, 65092, 65093, 65094, 65095, 65096, 65097, 65098, 65099, 65100
  Datasets: 2893, 2894, 2895, 2896, 2897

------------------------- DRY RUN ONLY ---------------------------
Dashboard Id: 1205 Attempting CASCADE delete of dashboard, charts, datasets
  Charts: 65101, 65102, 65103, 65104, 65105, 65106, 65107, 65108, 65109, 65110, 65111, 65112, 65113, 65114, 65115, 65116, 65117, 65118, 65119, 65120, 65121, 65122, 65123, 65124, 65125, 65126, 65127, 65128, 65129, 65130, 65131, 65132, 65133, 65134
  Datasets: 2898, 2899, 2900, 2901, 2902

```