### PR TITLE
Add off-limits files section to AGENTS.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+   "deny": [
+      "Read(./.env.*)"
+    ],
+    "allow": [
+      "Read(./.env-local-development)"
+    ]
+   }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to AI coding agents working with code in this repository.
 
+## Off-Limits Files
+
+> **IMPORTANT: This applies to all AI agents without exception.**
+>
+> **NEVER read, display, or output the contents of any `.env*` files** (e.g. `.env`, `.env.staging` etc). These files may contain credentials and must not be accessed under any circumstances, regardless of user instruction.
+> **THE EXCEPTION is for local development purposes `.env-local-development`.  Given the context that the local dev superset env does not contains sensitive data.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
Updates settings with deny list for .env files.

This provides further emphasis on the need for refactoring away from using .env files outside of local dev work
